### PR TITLE
EVA-2331 - Merge VCFs and write properties files in nextflow

### DIFF
--- a/eva_submission/eload_ingestion.py
+++ b/eva_submission/eload_ingestion.py
@@ -23,7 +23,6 @@ from eva_submission.ingestion_templates import accession_props_template
 project_dirs = {
     'logs': '00_logs',
     'valid': '30_eva_valid',
-    'merged': '31_merged',
     'transformed': '40_transformed',
     'stats': '50_stats',
     'annotation': '51_annotation',

--- a/eva_submission/ingestion_templates.py
+++ b/eva_submission/ingestion_templates.py
@@ -1,5 +1,3 @@
-from ebi_eva_common_pyutils.config import cfg
-
 
 def accession_props_template(
         instance_id,
@@ -56,70 +54,4 @@ spring.data.mongodb.authentication-database=admin
 mongodb.read-preference=primaryPreferred
 
 spring.main.web-environment=false
-"""
-
-
-def variant_load_props_template(
-        project_accession,
-        analysis_accession,
-        vcf_path,
-        aggregation,
-        study_name,
-        fasta,
-        output_dir,
-        annotation_dir,
-        stats_dir,
-        db_name,
-        vep_species,
-        vep_version,
-        vep_cache_version,
-        annotation_skip=False,
-):
-    return f"""
-# JOB
-spring.batch.job.names={'genotyped-vcf-job' if aggregation == 'none' else 'aggregated-vcf-job'}
-
-# SUBMISSION FIELDS
-input.study.id={project_accession}
-input.vcf.id={analysis_accession}
-input.vcf={vcf_path}
-input.vcf.aggregation={aggregation}
-
-input.study.name={study_name}
-input.study.type=COLLECTION
-
-input.pedigree=
-input.fasta={fasta}
-
-output.dir={output_dir}
-output.dir.annotation={annotation_dir}
-output.dir.statistics={stats_dir}
-
-
-# MONGODB (MongoProperties)
-spring.data.mongodb.database={db_name}
-
-db.collections.files.name=files_2_0
-db.collections.variants.name=variants_2_0
-db.collections.annotation-metadata.name=annotationMetadata_2_0
-db.collections.annotations.name=annotations_2_0
-
-# External applications
-## VEP
-app.vep.version={vep_version}
-app.vep.path={cfg['vep_path']}/ensembl-vep-release-{vep_version}/vep
-app.vep.cache.version={vep_cache_version}
-app.vep.cache.path={cfg['vep_cache_path']}
-app.vep.cache.species={vep_species}
-app.vep.num-forks=4
-app.vep.timeout=500
-
-
-# STEPS MANAGEMENT
-## Skip steps
-statistics.skip=false
-annotation.skip={annotation_skip}
-annotation.overwrite=false
-
-config.chunk.size=200
 """

--- a/eva_submission/ingestion_templates.py
+++ b/eva_submission/ingestion_templates.py
@@ -1,13 +1,13 @@
+from ebi_eva_common_pyutils.config import cfg
+
 
 def accession_props_template(
         instance_id,
         assembly_accession,
         taxonomy_id,
         project_accession,
-        vcf_path,
         aggregation,
         fasta,
-        output_vcf,
         report,
         postgres_url,
         postgres_user,
@@ -16,42 +16,86 @@ def accession_props_template(
         mongo_user,
         mongo_pass,
 ):
-    return f"""
-accessioning.instanceId=instance-{instance_id}
-accessioning.submitted.categoryId=ss
-accessioning.monotonic.ss.blockSize=100000
-accessioning.monotonic.ss.blockStartValue=5000000000
-accessioning.monotonic.ss.nextBlockInterval=1000000000
+    """
+    Get all properties needed for this accessioning job, except for the input
+    and output filenames which are filled in by Nextflow.
+    """
+    return {
+        'accessioning.instanceId': f'instance-{instance_id}',
+        'accessioning.submitted.categoryId': 'ss',
+        'accessioning.monotonic.ss.blockSize': 100000,
+        'accessioning.monotonic.ss.blockStartValue': 5000000000,
+        'accessioning.monotonic.ss.nextBlockInterval': 1000000000,
+        'parameters.assemblyAccession': assembly_accession,
+        'parameters.taxonomyAccession': taxonomy_id,
+        'parameters.projectAccession': project_accession,
+        'parameters.chunkSize': 100,
+        'parameters.vcfAggregation': aggregation,
+        'parameters.forceRestart': False,
+        'parameters.fasta': fasta,
+        'parameters.assemblyReportUrl': f'file:{report}',
+        'parameters.contigNaming': 'NO_REPLACEMENT',
+        'spring.batch.job.names': 'CREATE_SUBSNP_ACCESSION_JOB',
+        'spring.datasource.driver-class-name': 'org.postgresql.Driver',
+        'spring.datasource.url': postgres_url,
+        'spring.datasource.username': postgres_user,
+        'spring.datasource.password': postgres_pass,
+        'spring.datasource.tomcat.max-active': 3,
+        'spring.jpa.generate-ddl': True,
+        'spring.data.mongodb.host': mongo_host,
+        'spring.data.mongodb.port': 27017,
+        'spring.data.mongodb.database': 'eva_accession_sharded',
+        'spring.data.mongodb.username': mongo_user,
+        'spring.data.mongodb.password': mongo_pass,
+        'spring.data.mongodb.authentication-database': 'admin',
+        'mongodb.read-preference': 'primaryPreferred',
+        'spring.main.web-environment': False,
+    }
 
-parameters.assemblyAccession={assembly_accession}
-parameters.taxonomyAccession={taxonomy_id}
-parameters.projectAccession={project_accession}
-parameters.chunkSize=100
-parameters.vcf={vcf_path}
-parameters.vcfAggregation={aggregation}
-parameters.forceRestart=false
-parameters.fasta={fasta}
-parameters.outputVcf={output_vcf}
-parameters.assemblyReportUrl=file:{report}
-# contigNaming available values: SEQUENCE_NAME, ASSIGNED_MOLECULE, INSDC, REFSEQ, UCSC, NO_REPLACEMENT
-parameters.contigNaming=NO_REPLACEMENT
 
-spring.batch.job.names=CREATE_SUBSNP_ACCESSION_JOB
-
-spring.datasource.driver-class-name=org.postgresql.Driver
-spring.datasource.url={postgres_url}
-spring.datasource.username={postgres_user}
-spring.datasource.password={postgres_pass}
-spring.datasource.tomcat.max-active=3
-spring.jpa.generate-ddl=true
-
-spring.data.mongodb.host={mongo_host}
-spring.data.mongodb.port=27017
-spring.data.mongodb.database=eva_accession_sharded
-spring.data.mongodb.username={mongo_user}
-spring.data.mongodb.password={mongo_pass}
-spring.data.mongodb.authentication-database=admin
-mongodb.read-preference=primaryPreferred
-
-spring.main.web-environment=false
-"""
+def variant_load_props_template(
+        project_accession,
+        analysis_accession,
+        aggregation,
+        study_name,
+        fasta,
+        output_dir,
+        annotation_dir,
+        stats_dir,
+        db_name,
+        vep_species,
+        vep_version,
+        vep_cache_version
+):
+    """
+    Get all properties needed for this variant load job, except for the vcf file
+    which is filled in by Nextflow after (optional) merge.
+    """
+    return {
+        'spring.batch.job.names': 'genotyped-vcf-job' if aggregation == 'none' else 'aggregated-vcf-job',
+        'input.study.id': project_accession,
+        'input.vcf.id': analysis_accession,
+        'input.vcf.aggregation': aggregation,
+        'input.study.name': study_name,
+        'input.study.type': 'COLLECTION',
+        'input.fasta': fasta,
+        'output.dir': str(output_dir),
+        'output.dir.annotation': str(annotation_dir),
+        'output.dir.statistics': str(stats_dir),
+        'spring.data.mongodb.database': db_name,
+        'db.collections.files.name': 'files_2_0',
+        'db.collections.variants.name': 'variants_2_0',
+        'db.collections.annotation-metadata.name': 'annotationMetadata_2_0',
+        'db.collections.annotations.name': 'annotations_2_0',
+        'app.vep.version': vep_version,
+        'app.vep.path': f"{cfg['vep_path']}/ensembl-vep-release-{vep_version}/vep",
+        'app.vep.cache.version': vep_cache_version,
+        'app.vep.cache.path': cfg['vep_cache_path'],
+        'app.vep.cache.species': vep_species,
+        'app.vep.num-forks': 4,
+        'app.vep.timeout': 500,
+        'statistics.skip': False,
+        'annotation.skip': False,
+        'annotation.overwrite': False,
+        'config.chunk.size': 200,
+    }

--- a/nextflow/accession.nf
+++ b/nextflow/accession.nf
@@ -63,6 +63,7 @@ process create_properties {
     props = new Properties()
     props.putAll(params.accession_job_props)
     props.setProperty("parameters.vcf", vcf_file.toString())
+    props.setProperty("parameters.outputVcf", params.public_dir + "/" + vcf_file.getFileName())
     // need to explicitly store in workDir so next process can pick it up
     // see https://github.com/nextflow-io/nextflow/issues/942#issuecomment-441536175
     props_file = new File("${task.workDir}/${vcf_file}_accessioning.properties")

--- a/nextflow/accession.nf
+++ b/nextflow/accession.nf
@@ -53,7 +53,7 @@ process accession_vcf {
     memory '8 GB'
 
     input:
-        path accession_properties from accession_props
+    path accession_properties from accession_props
 
     """
     filename=\$(basename $accession_properties)
@@ -73,12 +73,11 @@ process compress_vcf {
 	mode: 'copy'
 
     input:
-        path vcf_file from accessioned_vcfs
+    path vcf_file from accessioned_vcfs
 
     output:
-        // used by both tabix and csi indexing processes
-        path "${vcf_file}.gz" into compressed_vcf1
-        path "${vcf_file}.gz" into compressed_vcf2
+    // used by both tabix and csi indexing processes
+    path "${vcf_file}.gz" into compressed_vcf1, compressed_vcf2
 
     """
     $params.executable.bgzip -c $vcf_file > ${vcf_file}.gz
@@ -94,10 +93,10 @@ process tabix_index_vcf {
 	mode: 'copy'
 
     input:
-        path compressed_vcf from compressed_vcf1
+    path compressed_vcf from compressed_vcf1
 
     output:
-        path "${compressed_vcf}.tbi" into tbi_indexed_vcf
+    path "${compressed_vcf}.tbi" into tbi_indexed_vcf
 
     """
     $params.executable.tabix -p vcf $compressed_vcf
@@ -110,10 +109,10 @@ process csi_index_vcf {
 	mode: 'copy'
 
     input:
-        path compressed_vcf from compressed_vcf2
+    path compressed_vcf from compressed_vcf2
 
     output:
-        path "${compressed_vcf}.csi" into csi_indexed_vcf
+    path "${compressed_vcf}.csi" into csi_indexed_vcf
 
     """
     $params.executable.bcftools index -c $compressed_vcf
@@ -126,9 +125,9 @@ process csi_index_vcf {
  */
  process copy_to_ftp {
     input:
-        // ensures that all indices are done before we copy
-        file csi_indices from csi_indexed_vcf.toList()
-        file tbi_indices from tbi_indexed_vcf.toList()
+    // ensures that all indices are done before we copy
+    file csi_indices from csi_indexed_vcf.toList()
+    file tbi_indices from tbi_indexed_vcf.toList()
 
     """
     cd $params.public_dir

--- a/nextflow/accession.nf
+++ b/nextflow/accession.nf
@@ -78,7 +78,7 @@ process create_properties {
  * Accession VCFs
  */
 process accession_vcf {
-    clusterOptions '-g /accession/instance-$params.instance_id'
+    clusterOptions "-g /accession/instance-${params.instance_id}"
 
     memory '8 GB'
 

--- a/nextflow/prepare_brokering.nf
+++ b/nextflow/prepare_brokering.nf
@@ -42,12 +42,12 @@ process compress_vcf {
             mode: "copy"
 
     input:
-        path vcf_file from vcf_channel
+    path vcf_file from vcf_channel
 
     output:
-        path "output/*.gz" into compressed_vcf1
-        path "output/*.gz" into compressed_vcf2
-        path "output/*.gz" into compressed_vcf3
+    path "output/*.gz" into compressed_vcf1
+    path "output/*.gz" into compressed_vcf2
+    path "output/*.gz" into compressed_vcf3
 
     """
     mkdir output
@@ -71,10 +71,10 @@ process csi_index_vcf {
             mode: "copy"
 
     input:
-        path compressed_vcf from compressed_vcf1
+    path compressed_vcf from compressed_vcf1
 
     output:
-        path "${compressed_vcf}.csi" into csi_indexed_vcf
+    path "${compressed_vcf}.csi" into csi_indexed_vcf
 
     """
     $params.executable.bcftools index -c $compressed_vcf
@@ -88,10 +88,10 @@ process tabix_index_vcf {
             mode: "copy"
 
     input:
-        path compressed_vcf from compressed_vcf2
+    path compressed_vcf from compressed_vcf2
 
     output:
-        path "${compressed_vcf}.tbi" into tbi_indexed_vcf
+    path "${compressed_vcf}.tbi" into tbi_indexed_vcf
 
     """
     $params.executable.tabix -p vcf $compressed_vcf
@@ -110,14 +110,14 @@ process md5_vcf_and_index {
             mode: "copy"
 
     input:
-        path vcf from compressed_vcf3
-        path index from tbi_indexed_vcf
-        path index2 from csi_indexed_vcf
+    path vcf from compressed_vcf3
+    path index from tbi_indexed_vcf
+    path index2 from csi_indexed_vcf
 
     output:
-        path "${vcf}.md5" into vcf_md5
-        path "${index}.md5" into index_md5
-        path "${index2}.md5" into index2_md5
+    path "${vcf}.md5" into vcf_md5
+    path "${index}.md5" into index_md5
+    path "${index2}.md5" into index2_md5
 
     """
     $params.executable.md5sum ${vcf} > ${vcf}.md5

--- a/nextflow/validation.nf
+++ b/nextflow/validation.nf
@@ -51,12 +51,12 @@ process check_vcf_valid {
             mode: "copy"
 
     input:
-        path vcf_file from vcf_channel1
+    path vcf_file from vcf_channel1
 
     output:
-        path "vcf_format/*.errors.*.db" into vcf_validation_db
-        path "vcf_format/*.errors.*.txt" into vcf_validation_txt
-        path "vcf_format/*.vcf_format.log" into vcf_validation_log
+    path "vcf_format/*.errors.*.db" into vcf_validation_db
+    path "vcf_format/*.errors.*.txt" into vcf_validation_txt
+    path "vcf_format/*.vcf_format.log" into vcf_validation_log
 
     validExitStatus 0,1
 
@@ -78,14 +78,14 @@ process check_vcf_reference {
             mode: "copy"
 
     input:
-        path "reference.fa" from params.reference_fasta
-        path "reference.report" from params.reference_report
-        path vcf_file from vcf_channel2
+    path "reference.fa" from params.reference_fasta
+    path "reference.report" from params.reference_report
+    path vcf_file from vcf_channel2
 
     output:
-        path "assembly_check/*valid_assembly_report*" into vcf_assembly_valid
-        path "assembly_check/*text_assembly_report*" into assembly_check_report
-        path "assembly_check/*.assembly_check.log" into assembly_check_log
+    path "assembly_check/*valid_assembly_report*" into vcf_assembly_valid
+    path "assembly_check/*text_assembly_report*" into assembly_check_report
+    path "assembly_check/*.assembly_check.log" into assembly_check_log
 
     validExitStatus 0,1,139
 

--- a/nextflow/variant_load.nf
+++ b/nextflow/variant_load.nf
@@ -5,16 +5,20 @@ def helpMessage() {
     Load variant files into variant warehouse.
 
     Inputs:
-            --variant_load_props    properties files for variant load
-            --eva_pipeline_props    main properties file for eva pipeline
+            --valid_vcfs            valid vcfs to load
+            --needs_merge           whether horizontal merge is required (false by default)
             --project_accession     project accession
+            --job_props             job-specific properties, passed as a map
+            --eva_pipeline_props    main properties file for eva pipeline
             --logs_dir              logs directory
     """
 }
 
-params.variant_load_props = null
-params.eva_pipeline_props = null
+params.valid_vcfs = null
+params.needs_merge = null
 params.project_accession = null
+params.job_props = null
+params.eva_pipeline_props = null
 params.logs_dir = null
 // executables
 params.executable = ["bgzip": "bgzip", "bcftools": "bcftools"]
@@ -26,33 +30,33 @@ params.help = null
 // Show help message
 if (params.help) exit 0, helpMessage()
 
-// Test input files
-if (!params.variant_load_props || !params.eva_pipeline_props) {
-    if (!params.variant_load_props) log.warn('Provide a variant load properties file using --variant_load_props')
+// Test inputs
+if (!params.valid_vcfs || !params.project_accession || !params.job_props || !params.eva_pipeline_props || !params.logs_dir) {
+    if (!params.valid_vcfs) log.warn('Provide validated vcfs using --valid_vcfs')
+    if (!params.project_accession) log.warn('Provide project accession using --project_accession')
+    if (!params.job_props) log.warn('Provide job-specific properties using --job_props')
     if (!params.eva_pipeline_props) log.warn('Provide an EVA Pipeline properties file using --eva_pipeline_props')
+    if (!params.logs_dir) log.warn('Provide logs directory using --logs_dir')
     exit 1, helpMessage()
 }
 
-//variant_load_props = Channel.fromPath(params.variant_load_props)
-
-
-// valid vcfs redirected to merge step or directly to load
-Channel.from(params.valid_vcfs)
-    .branch {
-	vcfs_to_merge: params.needs_merge
-	vcfs_to_load: true
-    }
+// Valid vcfs are redirected to merge step or directly to load
+// See https://nextflow-io.github.io/patterns/index.html#_skip_process_execution
+(vcfs_to_merge, unmerged_vcfs) = (
+    params.needs_merge
+    ? [Channel.from(params.valid_vcfs), Channel.empty()]
+    : [Channel.empty(), Channel.fromPath(params.valid_vcfs)] )
 
 
 /*
- * Merge VCFs by sample.
+ * Merge VCFs horizontally, i.e. by sample.
  */
 process merge_vcfs {
     input:
-    path file_list from vcfs_to_merge.collectFile('all_files.list', newLine: true)
+    path file_list from vcfs_to_merge.collectFile(name: 'all_files.list', newLine: true)
 
     output:
-    path ${params.project_accession}_merged.vcf into merged_vcf
+    path "${params.project_accession}_merged.vcf" into merged_vcf
 
     """
     $params.executable.bcftools merge --merge all --file-list $file_list --threads 3 -o ${params.project_accession}_merged.vcf
@@ -61,14 +65,14 @@ process merge_vcfs {
 
 
 /*
- * Compress merged vcf file.
+ * Compress merged VCF file.
  */
 process compress_vcf {
     input:
     path vcf_file from merged_vcf
 
     output:
-    path "${vcf_file}.gz" into vcfs_to_load
+    path "${vcf_file}.gz" into compressed_vcf
 
     """
     $params.executable.bgzip -c $vcf_file > ${vcf_file}.gz
@@ -76,19 +80,28 @@ process compress_vcf {
 }
 
 
+/*
+ * Create properties files for load.
+ */
 process create_properties {
-    publishDir params.project_dir,
-	mode: 'copy'
-
     input:
-    path vcf_file from vcfs_to_load
+    // note one of these channels is always empty
+    path vcf_file from unmerged_vcfs.mix(compressed_vcf)
 
     output:
     path "load_${vcf_file}.properties" into variant_load_props
 
-    """
-
-    """
+    exec:
+    props = new Properties()
+    props.putAll(params.job_props)
+    props.setProperty("input.vcf", vcf_file.toString())
+    // need to store in workDir so next process can pick it up
+    // this needs to happen explicitly in exec (as opposed to script)
+    props_file = new File("${task.workDir}/load_${vcf_file}.properties")
+    props_file.createNewFile()
+    props_file.withWriter { w ->
+	props.store(w, null)
+    }
 }
 
 
@@ -97,7 +110,7 @@ process create_properties {
  */
 process load_vcf {
     input:
-        path variant_load_properties from variant_load_props
+    path variant_load_properties from variant_load_props
 
     memory '5 GB'
 

--- a/nextflow/variant_load.nf
+++ b/nextflow/variant_load.nf
@@ -95,8 +95,8 @@ process create_properties {
     props = new Properties()
     props.putAll(params.job_props)
     props.setProperty("input.vcf", vcf_file.toString())
-    // need to store in workDir so next process can pick it up
-    // this needs to happen explicitly in exec (as opposed to script)
+    // need to explicitly store in workDir so next process can pick it up
+    // see https://github.com/nextflow-io/nextflow/issues/942#issuecomment-441536175
     props_file = new File("${task.workDir}/load_${vcf_file}.properties")
     props_file.createNewFile()
     props_file.withWriter { w ->

--- a/nextflow/variant_load.nf
+++ b/nextflow/variant_load.nf
@@ -8,7 +8,7 @@ def helpMessage() {
             --valid_vcfs            valid vcfs to load
             --needs_merge           whether horizontal merge is required (false by default)
             --project_accession     project accession
-            --job_props             job-specific properties, passed as a map
+            --load_job_props        job-specific properties, passed as a map
             --eva_pipeline_props    main properties file for eva pipeline
             --logs_dir              logs directory
     """
@@ -17,7 +17,7 @@ def helpMessage() {
 params.valid_vcfs = null
 params.needs_merge = null
 params.project_accession = null
-params.job_props = null
+params.load_job_props = null
 params.eva_pipeline_props = null
 params.logs_dir = null
 // executables
@@ -31,10 +31,10 @@ params.help = null
 if (params.help) exit 0, helpMessage()
 
 // Test inputs
-if (!params.valid_vcfs || !params.project_accession || !params.job_props || !params.eva_pipeline_props || !params.logs_dir) {
+if (!params.valid_vcfs || !params.project_accession || !params.load_job_props || !params.eva_pipeline_props || !params.logs_dir) {
     if (!params.valid_vcfs) log.warn('Provide validated vcfs using --valid_vcfs')
     if (!params.project_accession) log.warn('Provide project accession using --project_accession')
-    if (!params.job_props) log.warn('Provide job-specific properties using --job_props')
+    if (!params.load_job_props) log.warn('Provide job-specific properties using --load_job_props')
     if (!params.eva_pipeline_props) log.warn('Provide an EVA Pipeline properties file using --eva_pipeline_props')
     if (!params.logs_dir) log.warn('Provide logs directory using --logs_dir')
     exit 1, helpMessage()
@@ -93,7 +93,7 @@ process create_properties {
 
     exec:
     props = new Properties()
-    props.putAll(params.job_props)
+    props.putAll(params.load_job_props)
     props.setProperty("input.vcf", vcf_file.toString())
     // need to explicitly store in workDir so next process can pick it up
     // see https://github.com/nextflow-io/nextflow/issues/942#issuecomment-441536175

--- a/nextflow/variant_load.nf
+++ b/nextflow/variant_load.nf
@@ -56,26 +56,10 @@ process merge_vcfs {
     path file_list from vcfs_to_merge.collectFile(name: 'all_files.list', newLine: true)
 
     output:
-    path "${params.project_accession}_merged.vcf" into merged_vcf
+    path "${params.project_accession}_merged.vcf.gz" into merged_vcf
 
     """
-    $params.executable.bcftools merge --merge all --file-list $file_list --threads 3 -o ${params.project_accession}_merged.vcf
-    """
-}
-
-
-/*
- * Compress merged VCF file.
- */
-process compress_vcf {
-    input:
-    path vcf_file from merged_vcf
-
-    output:
-    path "${vcf_file}.gz" into compressed_vcf
-
-    """
-    $params.executable.bgzip -c $vcf_file > ${vcf_file}.gz
+    $params.executable.bcftools merge --merge all --file-list $file_list --threads 3 -O z -o ${params.project_accession}_merged.vcf.gz
     """
 }
 
@@ -86,7 +70,7 @@ process compress_vcf {
 process create_properties {
     input:
     // note one of these channels is always empty
-    path vcf_file from unmerged_vcfs.mix(compressed_vcf)
+    path vcf_file from unmerged_vcfs.mix(merged_vcf)
 
     output:
     path "load_${vcf_file}.properties" into variant_load_props

--- a/tests/nextflow-tests/bin/fake_bcftools.sh
+++ b/tests/nextflow-tests/bin/fake_bcftools.sh
@@ -2,5 +2,13 @@
 
 echo "bcftools $*"
 
-filename=$3
-touch ${filename}.csi
+if [[ $1 == "merge" ]]; then
+    filename=${*: -1}
+    touch $filename
+    printf "> Files merged:\n"
+    cat all_files.list
+    printf "\n"
+else
+    filename=$3
+    touch ${filename}.csi
+fi

--- a/tests/nextflow-tests/bin/fake_bgzip.sh
+++ b/tests/nextflow-tests/bin/fake_bgzip.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-echo "bgzip $*"
+# bgzip command eats stdout
+>&2 echo "bgzip $*"

--- a/tests/nextflow-tests/clean_tests.sh
+++ b/tests/nextflow-tests/clean_tests.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SOURCE_DIR="$(dirname $(dirname $SCRIPT_DIR))/nextflow"
+
+cwd=${PWD}
+cd ${SCRIPT_DIR}
+
+rm -rf work .nextflow*
+rm -r project
+cd ${cwd}

--- a/tests/nextflow-tests/test_ingestion_config.yaml
+++ b/tests/nextflow-tests/test_ingestion_config.yaml
@@ -6,9 +6,15 @@ public_dir: ../../../project/public
 accession_props:
 - accession_test1.vcf.gz.properties
 - accession_test2.vcf.gz.properties
-variant_load_props:
-- load_PRJEB12345_merged.vcf.gz.properties
+
+valid_vcfs:
+- test1.vcf.gz
+- test2.vcf.gz
+needs_merge: true
 eva_pipeline_props: test_eva_pipeline.properties
+job_props:
+  test.prop1: a
+  test.prop2: b
 
 executable:
   bcftools: ../../../bin/fake_bcftools.sh

--- a/tests/nextflow-tests/test_ingestion_config.yaml
+++ b/tests/nextflow-tests/test_ingestion_config.yaml
@@ -2,17 +2,16 @@ project_accession: PRJEB12345
 instance_id: 1
 logs_dir: ../../../project/logs
 public_dir: ../../../project/public
-
-accession_props:
-- accession_test1.vcf.gz.properties
-- accession_test2.vcf.gz.properties
-
 valid_vcfs:
 - test1.vcf.gz
 - test2.vcf.gz
+
+accession_job_props:
+  test.prop1: x
+  test.prop2: y
 needs_merge: true
 eva_pipeline_props: test_eva_pipeline.properties
-job_props:
+load_job_props:
   test.prop1: a
   test.prop2: b
 

--- a/tests/nextflow-tests/test_ingestion_nextflow.sh
+++ b/tests/nextflow-tests/test_ingestion_nextflow.sh
@@ -21,7 +21,7 @@ nextflow run ${SOURCE_DIR}/variant_load.nf -params-file test_ingestion_config.ya
 printf "\e[32m====== Files made public ======\e[0m\n"
 ls project/public
 printf "\n\e[32m======== Commands run ========\e[0m\n"
-find work/ -name '*.out' -exec cat {} \;
+find work/ \( -name '*.out' -o -name '*.err' \) -exec cat {} \;
 cat project/logs/*.log
 
 # clean up

--- a/tests/test_eload_ingestion.py
+++ b/tests/test_eload_ingestion.py
@@ -125,29 +125,7 @@ class TestEloadIngestion(TestCase):
                 self.eload.load_from_ena()
             m_execute.assert_called_once()
 
-    def test_merge_vcfs(self):
-        expected = ['tests/resources/projects/PRJEB12345/31_merged/PRJEB12345_merged.vcf.gz']
-        with patch('eva_submission.eload_ingestion.command_utils.run_command_with_output', autospec=True):
-            self.assertEqual(expected, sorted(str(x) for x in self.eload.merge_vcfs()))
-
-    def test_merge_vcfs_duplicate_names(self):
-        expected = [
-            'tests/resources/projects/PRJEB12345/30_eva_valid/test1.vcf.gz',
-            'tests/resources/projects/PRJEB12345/30_eva_valid/test2.vcf.gz'
-        ]
-        with patch('eva_submission.eload_ingestion.command_utils.run_command_with_output', autospec=True) as m_execute:
-            m_execute.side_effect = subprocess.CalledProcessError(
-                1, 'some command',
-                'Error: Duplicate sample names (HG002), use --force-samples to proceed anyway.'
-            )
-            self.assertEqual(expected, sorted(str(x) for x in self.eload.merge_vcfs()))
-
-    def test_merge_vcfs_error(self):
-        with patch('eva_submission.eload_ingestion.command_utils.run_command_with_output', autospec=True) as m_execute:
-            m_execute.side_effect = subprocess.CalledProcessError(1, 'some command')
-            with self.assertRaises(subprocess.CalledProcessError):
-                self.eload.merge_vcfs()
-            m_execute.assert_called_once()
+    # TODO test these ingest ones properly
 
     def test_ingest_all_tasks(self):
         with patch('eva_submission.eload_ingestion.get_properties_from_xml_file', autospec=True) as m_properties, \
@@ -200,9 +178,9 @@ class TestEloadIngestion(TestCase):
                 db_name='eva_hsapiens_grch38'
             )
             # multiple vcf files with no aggregation => merge
-            assert os.path.exists(
-                os.path.join(self.resources_folder, 'projects/PRJEB12345/load_PRJEB12345_merged.vcf.properties')
-            )
+            # assert os.path.exists(
+            #     os.path.join(self.resources_folder, 'projects/PRJEB12345/load_PRJEB12345_merged.vcf.properties')
+            # )
 
     def test_ingest_variant_load_basic_aggregation(self):
         with patch('eva_submission.eload_ingestion.get_properties_from_xml_file', autospec=True) as m_properties, \
@@ -221,7 +199,7 @@ class TestEloadIngestion(TestCase):
                 db_name='eva_hsapiens_grch38'
             )
             # multiple vcf files with aggregation => no merge
-            for filename in ('test1.vcf', 'test2.vcf'):
-                assert os.path.exists(
-                    os.path.join(self.resources_folder, f'projects/PRJEB12345/load_{filename}.properties')
-                )
+            # for filename in ('test1.vcf', 'test2.vcf'):
+            #     assert os.path.exists(
+            #         os.path.join(self.resources_folder, f'projects/PRJEB12345/load_{filename}.properties')
+            #     )

--- a/tests/test_eload_ingestion.py
+++ b/tests/test_eload_ingestion.py
@@ -126,6 +126,8 @@ class TestEloadIngestion(TestCase):
             m_execute.assert_called_once()
 
     # TODO test these ingest ones properly
+    # - check that yaml file for nextflow exists?
+    # - check it contains the right stuff?
 
     def test_ingest_all_tasks(self):
         with patch('eva_submission.eload_ingestion.get_properties_from_xml_file', autospec=True) as m_properties, \

--- a/tests/test_eload_ingestion.py
+++ b/tests/test_eload_ingestion.py
@@ -125,10 +125,6 @@ class TestEloadIngestion(TestCase):
                 self.eload.load_from_ena()
             m_execute.assert_called_once()
 
-    # TODO test these ingest ones properly
-    # - check that yaml file for nextflow exists?
-    # - check it contains the right stuff?
-
     def test_ingest_all_tasks(self):
         with patch('eva_submission.eload_ingestion.get_properties_from_xml_file', autospec=True) as m_properties, \
                 patch('eva_submission.eload_ingestion.psycopg2.connect', autospec=True), \
@@ -162,8 +158,11 @@ class TestEloadIngestion(TestCase):
                 tasks=['accession'],
                 db_name='eva_hsapiens_grch38'
             )
+            assert os.path.exists(
+                os.path.join(self.resources_folder, 'projects/PRJEB12345/accession_config_file.yaml')
+            )
 
-    def test_ingest_variant_load_no_aggregation(self):
+    def test_ingest_variant_load(self):
         with patch('eva_submission.eload_ingestion.get_properties_from_xml_file', autospec=True) as m_properties, \
                 patch('eva_submission.eload_ingestion.psycopg2.connect', autospec=True), \
                 patch('eva_submission.eload_ingestion.get_all_results_for_query') as m_get_results, \
@@ -179,29 +178,6 @@ class TestEloadIngestion(TestCase):
                 tasks=['variant_load'],
                 db_name='eva_hsapiens_grch38'
             )
-            # multiple vcf files with no aggregation => merge
-            # assert os.path.exists(
-            #     os.path.join(self.resources_folder, 'projects/PRJEB12345/load_PRJEB12345_merged.vcf.properties')
-            # )
-
-    def test_ingest_variant_load_basic_aggregation(self):
-        with patch('eva_submission.eload_ingestion.get_properties_from_xml_file', autospec=True) as m_properties, \
-                patch('eva_submission.eload_ingestion.psycopg2.connect', autospec=True), \
-                patch('eva_submission.eload_ingestion.get_all_results_for_query') as m_get_results, \
-                patch('eva_submission.eload_ingestion.pymongo.MongoClient', autospec=True) as m_get_mongo, \
-                patch('eva_submission.eload_ingestion.command_utils.run_command_with_output', autospec=True):
-            m_properties.return_value = self._fake_properties_dict()
-            m_get_mongo.return_value.__enter__.return_value = self._mock_mongodb_client()
-            m_get_results.return_value = [('Test Study Name')]
-            self.eload.ingest(
-                aggregation='basic',
-                vep_version=82,
-                vep_cache_version=82,
-                tasks=['variant_load'],
-                db_name='eva_hsapiens_grch38'
+            assert os.path.exists(
+                os.path.join(self.resources_folder, 'projects/PRJEB12345/load_config_file.yaml')
             )
-            # multiple vcf files with aggregation => no merge
-            # for filename in ('test1.vcf', 'test2.vcf'):
-            #     assert os.path.exists(
-            #         os.path.join(self.resources_folder, f'projects/PRJEB12345/load_{filename}.properties')
-            #     )

--- a/tests/test_xlsx_to_xml.py
+++ b/tests/test_xlsx_to_xml.py
@@ -1,5 +1,6 @@
 import os
 from unittest import TestCase
+from unittest.mock import patch
 from xml.etree.ElementTree import ElementTree
 
 from eva_submission.ENA_submission.xlsx_to_ENA_xml import add_project, new_project, new_analysis, add_analysis, \
@@ -43,7 +44,9 @@ class TestXlsToXml(TestCase):
 
     def test_add_project(self):
         root = new_project()
-        add_project(root, self.project_row)
+        with patch('eva_submission.ENA_submission.xlsx_to_ENA_xml.get_scientific_name_from_ensembl') as m_sci_name:
+            m_sci_name.return_value = 'Oncorhynchus mykiss'
+            add_project(root, self.project_row)
         print(prettify(ElementTree(root)))
 
     def test_add_analysis(self):
@@ -54,5 +57,7 @@ class TestXlsToXml(TestCase):
     def test_process_metadata_spreadsheet(self):
         brokering_folder = os.path.join(os.path.dirname(__file__), 'resources', 'brokering')
         metadata_file = os.path.join(brokering_folder, 'metadata_sheet.xlsx')
-        process_metadata_spreadsheet(metadata_file, brokering_folder, 'TEST1')
+        with patch('eva_submission.ENA_submission.xlsx_to_ENA_xml.get_scientific_name_from_ensembl') as m_sci_name:
+            m_sci_name.return_value = 'Oncorhynchus mykiss'
+            process_metadata_spreadsheet(metadata_file, brokering_folder, 'TEST1')
 

--- a/tests/test_xlsx_validation.py
+++ b/tests/test_xlsx_validation.py
@@ -1,5 +1,6 @@
 import os
 from unittest import TestCase
+from unittest.mock import patch
 
 from eva_submission import ROOT_DIR
 from eva_submission.xlsx.xlsx_validation import EvaXlsxValidator
@@ -36,5 +37,7 @@ class TestEvaXlsValidator(TestCase):
         self.assertEqual(self.validator_fail.error_list, expected_errors)
 
     def test_validate(self):
-        self.validator.validate()
+        with patch('eva_submission.xlsx.xlsx_validation.get_scientific_name_from_ensembl') as m_sci_name:
+            m_sci_name.return_value = 'Homo sapiens'
+            self.validator.validate()
         assert self.validator.error_list == []


### PR DESCRIPTION
* Merging VCFs moved to Nextflow, so now will happen in the cluster
* Properties files creation moved to Nextflow,  allows Nextflow to control more parts of the pipeline.  (I think this should actually let us run accessioning and variant load in parallel since they both just rely on the validated VCFs, but for now I haven't implemented that.)
* Also made Nextflow indentation consistent with documentation and made some other fixes.