### PR TITLE
EVA-2409 - treat skipped structural variants as a success in accessioning

### DIFF
--- a/eva_submission/eload_utils.py
+++ b/eva_submission/eload_utils.py
@@ -68,7 +68,9 @@ def get_metadata_conn():
 
 def get_mongo_creds():
     properties = get_properties_from_xml_file(cfg['maven']['environment'], cfg['maven']['settings_file'])
-    mongo_host = split_hosts(properties['eva.mongo.host'])[0][0]
+    # Use the primary mongo host from configuration:
+    # https://github.com/EBIvariation/configuration/blob/master/eva-maven-settings.xml#L111
+    mongo_host = split_hosts(properties['eva.mongo.host'])[1][0]
     mongo_user = properties['eva.mongo.user']
     mongo_pass = properties['eva.mongo.passwd']
     return mongo_host, mongo_user, mongo_pass

--- a/eva_submission/eload_utils.py
+++ b/eva_submission/eload_utils.py
@@ -70,6 +70,7 @@ def get_mongo_creds():
     properties = get_properties_from_xml_file(cfg['maven']['environment'], cfg['maven']['settings_file'])
     # Use the primary mongo host from configuration:
     # https://github.com/EBIvariation/configuration/blob/master/eva-maven-settings.xml#L111
+    # TODO: revisit once accessioning/variant pipelines can support multiple hosts
     mongo_host = split_hosts(properties['eva.mongo.host'])[1][0]
     mongo_user = properties['eva.mongo.user']
     mongo_pass = properties['eva.mongo.passwd']

--- a/nextflow/accession.nf
+++ b/nextflow/accession.nf
@@ -111,6 +111,7 @@ process accession_vcf {
     (java -Xmx7g -jar $params.jar.accession_pipeline --spring.config.name=\$filename) || \
     # If accessioning fails due to missing variants, but the only missing variants are structural variants,
     # then we should treat this as a success from the perspective of the automation.
+    # TODO revert once accessioning pipeline properly registers structural variants
         [[ \$(grep -o 'Skipped processing structural variant' ${params.logs_dir}/${log_filename}.log | wc -l) \
            == \$(grep -oP '\\d+(?= unaccessioned variants need to be checked)' ${params.logs_dir}/${log_filename}.log) ]]
     echo "done" > ${accessioned_filename}.tmp

--- a/nextflow/accession.nf
+++ b/nextflow/accession.nf
@@ -108,7 +108,7 @@ process accession_vcf {
     """
     filename=\$(basename $accession_properties)
     filename=\${filename%.*}
-    java -Xmx7g -jar $params.jar.accession_pipeline --spring.config.name=\$filename || \
+    (java -Xmx7g -jar $params.jar.accession_pipeline --spring.config.name=\$filename) || \
     # If accessioning fails due to missing variants, but the only missing variants are structural variants,
     # then we should treat this as a success from the perspective of the automation.
         [[ \$(grep -o 'Skipped processing structural variant' ${params.logs_dir}/${log_filename}.log | wc -l) \


### PR DESCRIPTION
This is the workaround discussed in the development meeting.  Skipped structural variants are treated as a success, but other types of skipped variants will still be treated as a failure.

Also modified mongo credentials method to ensure it fetches the primary host from the [current settings file](https://github.com/EBIvariation/configuration/blob/master/eva-maven-settings.xml#L111).