### PR TITLE
EVA-2364 - Add single reference sequences  support

### DIFF
--- a/bin/genome_downloader.py
+++ b/bin/genome_downloader.py
@@ -20,7 +20,7 @@ import sys
 
 from ebi_eva_common_pyutils.logger import logging_config as log_cfg
 
-from eva_submission.eload_utils import get_genome_fasta_and_report
+from eva_submission.eload_utils import get_reference_fasta_and_report
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from eva_submission.submission_config import load_config
@@ -54,7 +54,7 @@ def main():
     load_config()
 
     try:
-        assembly_fasta_path, assembly_report_path = get_genome_fasta_and_report(
+        assembly_fasta_path, assembly_report_path = get_reference_fasta_and_report(
             args.species_name, args.assembly_accession, args.output_directory, args.clear
         )
         logger.info('FASTA: ' + assembly_fasta_path)

--- a/eva_submission/eload_backlog.py
+++ b/eva_submission/eload_backlog.py
@@ -8,7 +8,7 @@ import requests
 from requests.auth import HTTPBasicAuth
 
 from eva_submission.eload_submission import Eload
-from eva_submission.eload_utils import get_metadata_conn, get_genome_fasta_and_report
+from eva_submission.eload_utils import get_metadata_conn, get_reference_fasta_and_report
 
 
 class EloadBacklog(Eload):
@@ -57,7 +57,7 @@ class EloadBacklog(Eload):
         self.eload_cfg.set('submission', 'scientific_name', value=sci_name)
         self.eload_cfg.set('submission', 'assembly_accession', value=asm_accession)
 
-        fasta_path, report_path = get_genome_fasta_and_report(sci_name, asm_accession)
+        fasta_path, report_path = get_reference_fasta_and_report(sci_name, asm_accession)
         self.eload_cfg.set('submission', 'assembly_fasta', value=fasta_path)
         self.eload_cfg.set('submission', 'assembly_report', value=report_path)
 

--- a/eva_submission/eload_submission.py
+++ b/eva_submission/eload_submission.py
@@ -9,7 +9,6 @@ from datetime import datetime
 from cached_property import cached_property
 from ebi_eva_common_pyutils.config import cfg
 from ebi_eva_common_pyutils.logger import AppLogger
-from ebi_eva_common_pyutils.reference import NCBIAssembly, NCBISequence
 from ebi_eva_common_pyutils.taxonomy.taxonomy import get_scientific_name_from_ensembl
 
 from eva_submission.eload_utils import get_reference_fasta_and_report, resolve_accession_from_text
@@ -225,9 +224,11 @@ class EloadPreparation(Eload):
         reference_accession = self.eload_cfg.query('submission', 'assembly_accession')
         if scientific_name and reference_accession:
                 assembly_fasta_path, assembly_report_path = get_reference_fasta_and_report(scientific_name, reference_accession)
+                if assembly_report_path:
+                    self.eload_cfg.set('submission', 'assembly_report', value=assembly_report_path)
+                else:
+                    self.warning(f'Assembly report was not set for {reference_accession}')
                 self.eload_cfg.set('submission', 'assembly_fasta', value=assembly_fasta_path)
-                self.eload_cfg.set('submission', 'assembly_report', value=assembly_report_path)
-
         else:
             self.error(f'Genome cannot be downloaded because for scientific_name: {scientific_name} and '
                        f'assembly_accession: {reference_accession}')

--- a/eva_submission/eload_submission.py
+++ b/eva_submission/eload_submission.py
@@ -9,10 +9,10 @@ from datetime import datetime
 from cached_property import cached_property
 from ebi_eva_common_pyutils.config import cfg
 from ebi_eva_common_pyutils.logger import AppLogger
+from ebi_eva_common_pyutils.reference import NCBIAssembly, NCBISequence
 from ebi_eva_common_pyutils.taxonomy.taxonomy import get_scientific_name_from_ensembl
-from ebi_eva_common_pyutils.variation.assembly_utils import retrieve_genbank_assembly_accessions_from_ncbi
 
-from eva_submission.eload_utils import get_genome_fasta_and_report
+from eva_submission.eload_utils import get_reference_fasta_and_report, resolve_accession_from_text
 from eva_submission.submission_config import EloadConfig
 from eva_submission.submission_in_ftp import FtpDepositBox
 from eva_submission.xlsx.xlsx_parser_eva import EvaXlsxReader, EvaXlsxWriter
@@ -191,18 +191,21 @@ class EloadPreparation(Eload):
 
     def detect_metadata_attributes(self):
         eva_metadata = EvaXlsxReader(self.eload_cfg.query('submission', 'metadata_spreadsheet'))
-        reference_gca = set()
+        reference_set = set()
         for analysis in eva_metadata.analysis:
             reference_txt = analysis.get('Reference')
-            reference_gca.update(retrieve_genbank_assembly_accessions_from_ncbi(reference_txt))
+            if reference_txt:
+                reference_set.update(resolve_accession_from_text(reference_txt))
+            else:
+                self.warning('Reference is missing for Analysis %s', analysis.get('Analysis Alias'))
 
-        if len(reference_gca) > 1:
-            self.warning('Multiple assemblies in project: %s', ', '.join(reference_gca))
+        if len(reference_set) > 1:
+            self.warning('Multiple assemblies in project: %s', ', '.join(reference_set))
             self.warning('Will look for the most recent assembly.')
-            reference_gca = [sorted(reference_gca)[-1]]
+            reference_set = {sorted(reference_set)[-1]}
 
-        if reference_gca:
-            self.eload_cfg.set('submission', 'assembly_accession', value=reference_gca.pop())
+        if reference_set:
+            self.eload_cfg.set('submission', 'assembly_accession', value=reference_set.pop())
         else:
             self.error('No genbank accession could be found for %s', reference_txt)
 
@@ -219,11 +222,12 @@ class EloadPreparation(Eload):
 
     def find_genome(self):
         scientific_name = self.eload_cfg.query('submission', 'scientific_name')
-        assembly_accession = self.eload_cfg.query('submission', 'assembly_accession')
-        if scientific_name and assembly_accession:
-            assembly_fasta_path, assembly_report_path = get_genome_fasta_and_report(scientific_name, assembly_accession)
-            self.eload_cfg.set('submission', 'assembly_fasta', value=assembly_fasta_path)
-            self.eload_cfg.set('submission', 'assembly_report', value=assembly_report_path)
+        reference_accession = self.eload_cfg.query('submission', 'assembly_accession')
+        if scientific_name and reference_accession:
+                assembly_fasta_path, assembly_report_path = get_reference_fasta_and_report(scientific_name, reference_accession)
+                self.eload_cfg.set('submission', 'assembly_fasta', value=assembly_fasta_path)
+                self.eload_cfg.set('submission', 'assembly_report', value=assembly_report_path)
+
         else:
             self.error(f'Genome cannot be downloaded because for scientific_name: {scientific_name} and '
-                       f'assembly_accession: {assembly_accession}')
+                       f'assembly_accession: {reference_accession}')

--- a/eva_submission/eload_utils.py
+++ b/eva_submission/eload_utils.py
@@ -37,23 +37,17 @@ def resolve_accession_from_text(reference_text):
     :return:
     """
     # first Check if it is an reference genome
-    try:
-        NCBIAssembly.check_assembly_accession_format(reference_text)
-        return reference_text
-    except ValueError:
-        pass
-
+    if NCBIAssembly.is_assembly_accession_format(reference_text):
+        return [reference_text]
     # Search for a reference genome that resolve this text
     accession = retrieve_genbank_assembly_accessions_from_ncbi(reference_text)
     if accession:
         return accession
 
     # then check if this is a single INSDC accession
-    try:
-        NCBISequence.check_genbank_accession_format(reference_text)
+    if NCBISequence.is_genbank_accession_format(reference_text):
+        return [reference_text]
 
-    except ValueError:
-        pass
     return None
 
 

--- a/eva_submission/eload_utils.py
+++ b/eva_submission/eload_utils.py
@@ -2,25 +2,59 @@ import glob
 import os
 from urllib.parse import urlsplit
 
-from ebi_eva_common_pyutils.assembly import NCBIAssembly
+from ebi_eva_common_pyutils.reference import NCBIAssembly, NCBISequence
 from ebi_eva_common_pyutils.config import cfg
 from ebi_eva_common_pyutils.config_utils import get_properties_from_xml_file
 from ebi_eva_common_pyutils.logger import logging_config as log_cfg
 import psycopg2
+from ebi_eva_common_pyutils.variation.assembly_utils import retrieve_genbank_assembly_accessions_from_ncbi
 from pymongo.uri_parser import split_hosts
 
 logger = log_cfg.get_logger(__name__)
 
 
-def get_genome_fasta_and_report(species_name, assembly_accession, output_directory=None, overwrite=False):
+def get_reference_fasta_and_report(species_name, reference_accession, output_directory=None, overwrite=False):
     output_directory = output_directory or cfg.query('genome_downloader', 'output_directory')
-    assembly = NCBIAssembly(
-        assembly_accession, species_name, output_directory,
-        eutils_api_key=cfg['eutils_api_key']
-    )
-    if not os.path.isfile(assembly.assembly_fasta_path) or not os.path.isfile(assembly.assembly_report_path) or overwrite:
-        assembly.download_or_construct(overwrite=overwrite)
-    return assembly.assembly_fasta_path, assembly.assembly_report_path
+    if NCBIAssembly.is_assembly_accession_format(reference_accession):
+        assembly = NCBIAssembly(
+            reference_accession, species_name, output_directory,
+            eutils_api_key=cfg['eutils_api_key']
+        )
+        if not os.path.isfile(assembly.assembly_fasta_path) or not os.path.isfile(assembly.assembly_report_path) or overwrite:
+            assembly.download_or_construct(overwrite=overwrite)
+        return assembly.assembly_fasta_path, assembly.assembly_report_path
+    elif NCBISequence.is_genbank_accession_format(reference_accession):
+        reference = NCBISequence(reference_accession, species_name, output_directory,
+                                 eutils_api_key=cfg['eutils_api_key'])
+        if not os.path.isfile(reference.sequence_fasta_path) or overwrite:
+            reference.download_contig_sequence_from_ncbi(genbank_only=True)
+        return reference.sequence_fasta_path, None
+
+
+def resolve_accession_from_text(reference_text):
+    """
+    :param reference_text:
+    :return:
+    """
+    # first Check if it is an reference genome
+    try:
+        NCBIAssembly.check_assembly_accession_format(reference_text)
+        return reference_text
+    except ValueError:
+        pass
+
+    # Search for a reference genome that resolve this text
+    accession = retrieve_genbank_assembly_accessions_from_ncbi(reference_text)
+    if accession:
+        return accession
+
+    # then check if this is a single INSDC accession
+    try:
+        NCBISequence.check_genbank_accession_format(reference_text)
+
+    except ValueError:
+        pass
+    return None
 
 
 def resolve_single_file_path(file_path):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 cached-property
 cerberus
-#ebi_eva_common_pyutils==0.3.12
-git+https://github.com/tcezard/eva-common-pyutils.git@EVA2364_support_single_sequence#egg=ebi_eva_common_pyutils
+ebi_eva_common_pyutils==0.3.12
 humanize
 lxml
 openpyxl

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 cached-property
 cerberus
-ebi_eva_common_pyutils
+#ebi_eva_common_pyutils==0.3.12
+git+https://github.com/tcezard/eva-common-pyutils.git@EVA2364_support_single_sequence#egg=ebi_eva_common_pyutils
 humanize
 lxml
 openpyxl

--- a/tests/resources/submission_config.yml
+++ b/tests/resources/submission_config.yml
@@ -6,6 +6,9 @@ eva_pipeline_props: '/path/to/pipeline/properties'
 vep_path: '/path/to/vep'
 vep_cache_path: '/path/to/vep/cache'
 
+genome_downloader:
+  output_directory: 'tests/resources/genomes'
+
 maven:
   environment: 'internal'
   settings_file: 'path/to/settings/file'

--- a/tests/test_eload_backlog.py
+++ b/tests/test_eload_backlog.py
@@ -48,7 +48,7 @@ class TestEloadBacklog(TestCase):
         }
         with patch('eva_submission.eload_backlog.get_metadata_conn', autospec=True), \
                 patch('eva_submission.eload_backlog.get_all_results_for_query') as m_get_results, \
-                patch('eva_submission.eload_backlog.get_genome_fasta_and_report') as m_get_genome, \
+                patch('eva_submission.eload_backlog.get_reference_fasta_and_report') as m_get_genome, \
                 patch('eva_submission.eload_backlog.requests.post') as m_post:
             m_get_results.side_effect = [
                 [['PRJEB12345']],

--- a/tests/test_eload_submission.py
+++ b/tests/test_eload_submission.py
@@ -75,4 +75,4 @@ class TestEload(TestCase):
         self.eload.eload_cfg.set('submission', 'assembly_accession', value='AJ312413.2')
         self.eload.find_genome()
         assert self.eload.eload_cfg['submission']['assembly_fasta'] == 'tests/resources/genomes/thingy_thingus/AJ312413.2/AJ312413.2.fa'
-        assert self.eload.eload_cfg['submission']['assembly_report'] is None
+        assert 'assembly_report' not in self.eload.eload_cfg['submission']

--- a/tests/test_eload_submission.py
+++ b/tests/test_eload_submission.py
@@ -3,6 +3,8 @@ import os
 import shutil
 from unittest import TestCase
 
+from ebi_eva_common_pyutils.config import cfg
+
 from eva_submission import ROOT_DIR
 from eva_submission.eload_submission import EloadPreparation
 from eva_submission.submission_config import load_config
@@ -67,3 +69,10 @@ class TestEload(TestCase):
         assert reader.project['Tax ID'] == 10000
         assert reader.analysis[0]['Reference'] == 'GCA_000009999.9'
 
+    def test_find_genome_single_sequence(self):
+        cfg.content['eutils_api_key'] = None
+        self.eload.eload_cfg.set('submission', 'scientific_name', value='Thingy thingus')
+        self.eload.eload_cfg.set('submission', 'assembly_accession', value='AJ312413.2')
+        self.eload.find_genome()
+        assert self.eload.eload_cfg['submission']['assembly_fasta'] == 'tests/resources/genomes/thingy_thingus/AJ312413.2/AJ312413.2.fa'
+        assert self.eload.eload_cfg['submission']['assembly_report'] is None


### PR DESCRIPTION
This only adds support for the download of single reference sequence.
Because it does not have any assembly report some of the validation steps are not working.