### PR TITLE
Backlog automation fixes

### DIFF
--- a/bin/prepare_backlog_study.py
+++ b/bin/prepare_backlog_study.py
@@ -47,6 +47,7 @@ def main():
 
     preparation = EloadBacklog(args.eload)
     preparation.fill_in_config()
+    preparation.report()
 
     validation = EloadValidation(args.eload)
     validation_tasks = ['assembly_check', 'vcf_check']

--- a/eva_submission/eload_backlog.py
+++ b/eva_submission/eload_backlog.py
@@ -125,3 +125,22 @@ class EloadBacklog(Eload):
             if not hold_date:
                 raise ValueError(f"Couldn't get hold date from ENA for {self.project_accession} ({self.project_alias})")
         self.eload_cfg.set('brokering', 'ena', 'hold_date', value=hold_date)
+
+    def report(self):
+        """Collect information from the config and write the report."""
+        report_data = {
+            'project': self.eload_cfg.query('brokering', 'ena', 'PROJECT'),
+            'analysis': self.eload_cfg.query('brokering', 'ena', 'ANALYSIS'),
+            'vcf': self.eload_cfg.query('submission', 'vcf_files'),
+            'assembly': self.eload_cfg.query('submission', 'assembly_accession'),
+            'fasta': self.eload_cfg.query('submission', 'assembly_fasta')
+        }
+
+        report = """Results of backlog study preparation:
+Project accession: {project}
+Assembly: {assembly}
+    Fasta file: {fasta}
+Analysis accession: {analysis}
+    VCF file: {vcf}
+"""
+        print(report.format(**report_data))


### PR DESCRIPTION
Fixes to backlog automation found while running [ELOAD-506](https://www.ebi.ac.uk/panda/jira/browse/ELOAD-506).

* Use public date from ENA if no hold date
* Output a report so user can confirm analysis/assembly details

The issue of suppressed analysis is postponed to [EVA-2442](https://www.ebi.ac.uk/panda/jira/browse/EVA-2442).