### PR TITLE
EVA-2451 Make scripts in bin executable

### DIFF
--- a/bin/broker_submission.py
+++ b/bin/broker_submission.py
@@ -15,13 +15,10 @@
 # limitations under the License.
 
 import logging
-import os
-import sys
 from argparse import ArgumentParser
 
 from ebi_eva_common_pyutils.logger import logging_config as log_cfg
 
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from eva_submission.eload_brokering import EloadBrokering
 from eva_submission.submission_config import load_config
 

--- a/bin/check_samples_eva.py
+++ b/bin/check_samples_eva.py
@@ -1,12 +1,7 @@
 import argparse
 import logging
-import os
-import sys
 
 from ebi_eva_common_pyutils.logger import logging_config as log_cfg
-
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
 from eva_submission.submission_config import load_config
 from eva_submission.samples_checker import compare_spreadsheet_and_vcf
 

--- a/bin/detect_submission.py
+++ b/bin/detect_submission.py
@@ -15,14 +15,9 @@
 # limitations under the License.
 
 import logging
-import os
-import sys
 from argparse import ArgumentParser
 
 from ebi_eva_common_pyutils.logger import logging_config as log_cfg
-
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
 from eva_submission.submission_config import load_config
 from eva_submission.submission_in_ftp import inspect_all_users, inspect_one_user
 

--- a/bin/genome_downloader.py
+++ b/bin/genome_downloader.py
@@ -15,14 +15,12 @@
 # limitations under the License.
 import argparse
 import logging
-import os
 import sys
 
 from ebi_eva_common_pyutils.logger import logging_config as log_cfg
 
 from eva_submission.eload_utils import get_reference_fasta_and_report
 
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from eva_submission.submission_config import load_config
 
 
@@ -43,7 +41,6 @@ def main():
                         action='store_true')
     parser.add_argument('--debug', action='store_true', default=False,
                         help='Set the script to output logging information at debug level')
-    parser.add_argument('-h', '--help', action='help', help='Show this help message and exit')
     args = parser.parse_args()
 
     log_cfg.add_stdout_handler()
@@ -55,7 +52,7 @@ def main():
 
     try:
         assembly_fasta_path, assembly_report_path = get_reference_fasta_and_report(
-            args.species_name, args.assembly_accession, args.output_directory, args.clear
+            args.species, args.assembly_accession, args.output_directory, args.clear
         )
         logger.info('FASTA: ' + assembly_fasta_path)
         logger.info('REPORT: ' + assembly_report_path)

--- a/bin/ingest_submission.py
+++ b/bin/ingest_submission.py
@@ -15,13 +15,10 @@
 # limitations under the License.
 
 import logging
-import os
-import sys
+
 from argparse import ArgumentParser
 
 from ebi_eva_common_pyutils.logger import logging_config as log_cfg
-
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from eva_submission.eload_ingestion import EloadIngestion
 from eva_submission.submission_config import load_config
 

--- a/bin/ingest_submission.py
+++ b/bin/ingest_submission.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import logging
-
 from argparse import ArgumentParser
 
 from ebi_eva_common_pyutils.logger import logging_config as log_cfg

--- a/bin/prepare_backlog_study.py
+++ b/bin/prepare_backlog_study.py
@@ -15,13 +15,9 @@
 # limitations under the License.
 
 import logging
-import os
-import sys
 from argparse import ArgumentParser
 
 from ebi_eva_common_pyutils.logger import logging_config as log_cfg
-
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from eva_submission.eload_backlog import EloadBacklog
 from eva_submission.eload_validation import EloadValidation

--- a/bin/prepare_submission.py
+++ b/bin/prepare_submission.py
@@ -15,13 +15,9 @@
 # limitations under the License.
 
 import logging
-import os
-import sys
 from argparse import ArgumentParser
 
 from ebi_eva_common_pyutils.logger import logging_config as log_cfg
-
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from eva_submission.submission_config import load_config
 from eva_submission.eload_submission import EloadPreparation

--- a/bin/validate_submission.py
+++ b/bin/validate_submission.py
@@ -15,13 +15,10 @@
 # limitations under the License.
 
 import logging
-import os
-import sys
 from argparse import ArgumentParser
 
 from ebi_eva_common_pyutils.logger import logging_config as log_cfg
 
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from eva_submission.eload_validation import EloadValidation
 from eva_submission.submission_config import load_config
 
@@ -39,7 +36,7 @@ def main():
                                'evaluation. This does not affect the actual report but only change the final '
                                'evaluation')
     argparse.add_argument('--report', action='store_true', default=False,
-                      help='Set the script to only report the results based on previously run validation.')
+                          help='Set the script to only report the results based on previously run validation.')
 
     argparse.add_argument('--debug', action='store_true', default=False,
                           help='Set the script to output logging information at debug level')

--- a/eva_submission/eload_brokering.py
+++ b/eva_submission/eload_brokering.py
@@ -54,7 +54,10 @@ class EloadBrokering(Eload):
             # Upload the VCF to ENA FTP
             ena_uploader = ENAUploader(self.eload)
             files_to_upload = [vcf_file for vcf_file in self.eload_cfg['brokering']['vcf_files']] + \
-                              [self.eload_cfg['brokering']['vcf_files'][vcf_file]['index'] for vcf_file in self.eload_cfg['brokering']['vcf_files']]
+                              [
+                                  self.eload_cfg['brokering']['vcf_files'][vcf_file]['index']
+                                  for vcf_file in self.eload_cfg['brokering']['vcf_files']
+                              ]
             ena_uploader.upload_vcf_files_to_ena_ftp(files_to_upload)
 
             # Upload XML to ENA
@@ -155,7 +158,7 @@ class EloadBrokering(Eload):
         results = self.eload_cfg.query('brokering', 'ena', ret_default={})
         report_data = {
             'ena_accessions': '\n'.join(['%s: %s' % (t, results.get(t))
-                                         for t in ['PROJECT','SUBMISSION', 'ANALYSIS'] if t in results]),
+                                         for t in ['PROJECT', 'SUBMISSION', 'ANALYSIS'] if t in results]),
             'hold_date': results.get('hold_date', ''),
             'pass': 'PASS' if results.get('pass') else 'FAIL',
             'errors': '\n'.join(results.get('errors', [])),

--- a/eva_submission/eload_validation.py
+++ b/eva_submission/eload_validation.py
@@ -282,7 +282,7 @@ class EloadValidation(Eload):
                 'pass': 'PASS' if results.get('nb_error') == 0 and results.get('nb_mismatch') == 0 else 'FAIL',
                 '10_error_list': '\n'.join(results['error_list']),
                 '10_mismatch_list': '\n'.join(results['mismatch_list']),
-                'perc': results.get('ref_match') / (results.get('nb_variant') or 1)
+                'perc': (results.get('ref_match') or 0) / (results.get('nb_variant') or 1)
             }
             report_data.update(results)
             reports.append("""  * {vcf_file}: {pass}
@@ -309,7 +309,6 @@ class EloadValidation(Eload):
     - Samples that appear in the Metadata sheet but not in the VCF file(s): {in_metadata_not_in_VCF}
 """.format(**report_data))
         return '\n'.join(reports)
-
 
     def report(self):
         """Collect information from the config and write the report."""

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,14 @@ import glob
 from distutils.core import setup
 from os.path import join, abspath, dirname
 
-requirements_txt = join(abspath(dirname(__file__)), 'requirements.txt')
+base_dir = abspath(dirname(__file__))
+requirements_txt = join(base_dir, 'requirements.txt')
 requirements = [l.strip() for l in open(requirements_txt) if l and not l.startswith('#')]
 
 setup(
     name='eva_submission',
-    packages=['eva_submission'],
-    version='0.5.5',
+    packages=['eva_submission', 'eva_submission.ENA_submission', 'eva_submission.xlsx'],
+    version='0.5.6',
     license='Apache',
     description='EBI EVA - submission processing tools',
     url='https://github.com/EBIVariation/eva-submission',


### PR DESCRIPTION
Also fix a bug in validation report and genome downloader
Scripts will be executable after deployment with [deploy_python_in_venv.sh](https://github.com/EBIvariation/eva-tools/pull/111/files)