### PR TITLE
EVA-2454 - Fixes for backlog automation

### DIFF
--- a/eva_submission/eload_backlog.py
+++ b/eva_submission/eload_backlog.py
@@ -16,7 +16,10 @@ class EloadBacklog(Eload):
 
     def fill_in_config(self):
         """Fills in config params from metadata DB and ENA, enabling later parts of pipeline to run."""
-        self.eload_cfg.clear()
+        if not self.eload_cfg.is_empty():
+            self.error(f'Already found a config file for {self.eload} while running backlog preparation')
+            self.error('Please remove the existing config file and try again.')
+            raise ValueError(f'Already found a config file for {self.eload} while running backlog preparation')
         self.eload_cfg.set('brokering', 'ena', 'PROJECT', value=self.project_accession)
         self.get_analysis_info()
         self.get_species_info()

--- a/eva_submission/submission_config.py
+++ b/eva_submission/submission_config.py
@@ -30,8 +30,8 @@ class EloadConfig(Configuration):
             top_level = top_level[p]
         top_level[path[-1]] = value
 
-    def clear(self):
-        self.content = {}
+    def is_empty(self):
+        return not self.content
 
     def __setitem__(self, item, value):
         """Allow dict-style write access, e.g. config['this']='that'."""

--- a/tests/test_eload_backlog.py
+++ b/tests/test_eload_backlog.py
@@ -87,4 +87,5 @@ class TestEloadBacklog(TestCase):
             with self.assertRaises(FileNotFoundError):
                 self.eload.fill_in_config()
             # incomplete config should still exist, even though filling config failed
+            self.eload = EloadBacklog(44)
             self.assertEqual(self.eload.eload_cfg.content, expected_config)


### PR DESCRIPTION
* Backlog preparation will now always start with a clean config, so that any errors from previous runs aren't propagated.
* As a sanity check, ingestion automation throws an error if there's anything in the `valid` directory (i.e. about to be accessioned/loaded) that isn't explicitly listed in the brokering config.