### PR TITLE
EVA-2445 - Use secondaryPreferred reads in Mongo 4.0 environment

### DIFF
--- a/eva_submission/ingestion_templates.py
+++ b/eva_submission/ingestion_templates.py
@@ -48,7 +48,7 @@ def accession_props_template(
         'spring.data.mongodb.username': mongo_user,
         'spring.data.mongodb.password': mongo_pass,
         'spring.data.mongodb.authentication-database': 'admin',
-        'mongodb.read-preference': 'primaryPreferred',
+        'mongodb.read-preference': 'secondaryPreferred',
         'spring.main.web-environment': False,
         'spring.main.allow-bean-definition-overriding': True,
         'spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation': True,


### PR DESCRIPTION
Use secondaryPreferred reads in Mongo 4.0 environment for both accessioning and ingestion pipelines