### PR TITLE
EVA-2560 - Check analysis alias collisions during validation

### DIFF
--- a/eva_submission/eload_ingestion.py
+++ b/eva_submission/eload_ingestion.py
@@ -74,14 +74,16 @@ class EloadIngestion(Eload):
         if do_accession:
             self.eload_cfg.set(self.config_section, 'accession', 'instance_id', value=instance_id)
             self.update_config_with_hold_date(self.project_accession)
-            self.run_accession_workflow(vcf_files_to_ingest)
+            output_dir = self.run_accession_workflow(vcf_files_to_ingest)
+            shutil.rmtree(output_dir)
             self.insert_browsable_files()
             self.refresh_study_browser()
 
         if do_variant_load:
             self.eload_cfg.set(self.config_section, 'variant_load', 'vep', 'version', value=vep_version)
             self.eload_cfg.set(self.config_section, 'variant_load', 'vep', 'cache_version', value=vep_cache_version)
-            self.run_variant_load_workflow(vep_version, vep_cache_version, skip_annotation, vcf_files_to_ingest)
+            output_dir = self.run_variant_load_workflow(vep_version, vep_cache_version, skip_annotation, vcf_files_to_ingest)
+            shutil.rmtree(output_dir)
 
     def _get_vcf_files_from_brokering(self):
         vcf_files = []

--- a/eva_submission/eload_validation.py
+++ b/eva_submission/eload_validation.py
@@ -9,6 +9,7 @@ from ebi_eva_common_pyutils import command_utils
 from ebi_eva_common_pyutils.config import cfg
 from eva_vcf_merge.detect import detect_merge_type, MergeType
 from eva_vcf_merge.merge import VCFMerger
+from eva_vcf_merge.utils import validate_aliases
 
 from eva_submission import NEXTFLOW_DIR
 from eva_submission.eload_submission import Eload
@@ -110,11 +111,14 @@ class EloadValidation(Eload):
                 self.error('Unsupported merge type!')
 
         if merge_per_analysis:
+            if not validate_aliases(vcfs_by_analysis.keys()):
+                self.error('Analysis aliases not valid as merged filenames, will not merge.')
+                return
             merger = VCFMerger(
                 bcftools_binary=cfg['executable']['bcftools'],
                 bgzip_binary=cfg['executable']['bgzip'],
                 nextflow_binary=cfg['executable']['nextflow'],
-                nextflow_config=None,  # TODO do we have a nextflow config?
+                nextflow_config=None,  # uses default Nextflow config
                 output_dir=self._get_dir('merge')
             )
             merged_files = {}

--- a/eva_submission/eload_validation.py
+++ b/eva_submission/eload_validation.py
@@ -113,6 +113,10 @@ class EloadValidation(Eload):
         if merge_per_analysis:
             if not validate_aliases(vcfs_by_analysis.keys()):
                 self.error('Analysis aliases not valid as unique merged filenames, will not merge.')
+                self.eload_cfg.set(
+                    'validation', 'merge_errors',
+                    value=['Analysis aliases not valid as unique merged filenames']
+                )
                 return
             merger = VCFMerger(
                 bcftools_binary=cfg['executable']['bcftools'],
@@ -387,9 +391,15 @@ class EloadValidation(Eload):
         analysis_merge_dict = self.eload_cfg.query('validation', 'merge_type')
         if not analysis_merge_dict:
             return '  No mergeable VCFs\n'
-        reports = []
+        reports = ['  Merge types:']
         for analysis_alias, merge_type in analysis_merge_dict.items():
             reports.append(f'  * {analysis_alias}: {merge_type}')
+
+        errors = self.eload_cfg.query('validation', 'merge_errors')
+        if errors:
+            reports.append('  Errors:')
+            for error in errors:
+                reports.append(f'  * {error}')
         return '\n'.join(reports)
 
     def report(self):

--- a/eva_submission/eload_validation.py
+++ b/eva_submission/eload_validation.py
@@ -112,7 +112,7 @@ class EloadValidation(Eload):
 
         if merge_per_analysis:
             if not validate_aliases(vcfs_by_analysis.keys()):
-                self.error('Analysis aliases not valid as merged filenames, will not merge.')
+                self.error('Analysis aliases not valid as unique merged filenames, will not merge.')
                 return
             merger = VCFMerger(
                 bcftools_binary=cfg['executable']['bcftools'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cached-property
 cerberus
 ebi_eva_common_pyutils==0.3.15
-eva-vcf-merge
+eva-vcf-merge==0.0.2
 humanize
 lxml
 openpyxl

--- a/tests/test_eload_validation.py
+++ b/tests/test_eload_validation.py
@@ -189,3 +189,7 @@ VCF merge:
             self.validation.detect_and_optionally_merge(True)
             # Valid files should be unchanged even though merge is detected
             self.assertEqual(self.validation.eload_cfg.query('validation', 'valid', 'analyses'), analyses_dict)
+            self.assertEqual(
+                self.validation.eload_cfg.query('validation', 'merge_errors'),
+                ['Analysis aliases not valid as unique merged filenames']
+            )

--- a/tests/test_eload_validation.py
+++ b/tests/test_eload_validation.py
@@ -106,6 +106,7 @@ Sample names check:
 ----------------------------------
 
 VCF merge:
+  Merge types:
   * a1: horizontal
 
 ----------------------------------

--- a/tests/test_eload_validation.py
+++ b/tests/test_eload_validation.py
@@ -20,6 +20,11 @@ class TestEloadValidation(TestCase):
         # Need to set the directory so that the relative path set in the config file works from the top directory
         os.chdir(ROOT_DIR)
         self.validation = EloadValidation(2)
+        # Used to restore test config after each test
+        self.original_cfg = deepcopy(self.validation.eload_cfg.content)
+
+    def tearDown(self):
+        self.validation.eload_cfg.content = self.original_cfg
 
     def test_parse_assembly_check_log_failed(self):
         assembly_check_log = os.path.join(self.resources_folder, 'validations', 'failed_assembly_check.log')
@@ -137,7 +142,6 @@ VCF merge:
         self.validation.eload_cfg.content = original_content
 
     def test_merge_multiple_analyses(self):
-        original_content = deepcopy(self.validation.eload_cfg.content)
         valid_files = {
             'horizontal': ['h1', 'h2'],
             'vertical': ['v1', 'v2'],
@@ -166,4 +170,21 @@ VCF merge:
                 self.validation.eload_cfg.query('validation', 'valid', 'analyses', 'neither', 'vcf_files'),
                 ['n1', 'n2']
             )
-        self.validation.eload_cfg.content = original_content
+
+    def test_merge_multiple_analyses_same_name(self):
+        valid_files = {
+            'a!': ['h1', 'h2'],
+            'a@': ['v1', 'v2'],
+            'a2': ['n1', 'n2']
+        }
+        detections = [MergeType.HORIZONTAL, MergeType.VERTICAL, None]
+        analyses_dict = {
+            analysis_alias: {'vcf_files': vcf_files}
+            for analysis_alias, vcf_files in valid_files.items()
+        }
+        self.validation.eload_cfg.set('validation', 'valid', 'analyses', value=analyses_dict)
+
+        with patch('eva_submission.eload_validation.detect_merge_type', side_effect=detections):
+            self.validation.detect_and_optionally_merge(True)
+            # Valid files should be unchanged even though merge is detected
+            self.assertEqual(self.validation.eload_cfg.query('validation', 'valid', 'analyses'), analyses_dict)


### PR DESCRIPTION
Also implemented removing nextflow work directory during the ingestion automation, as an easy space-saving measure.