### PR TITLE
EVA-2580 - Fixes for variant load

### DIFF
--- a/eva_submission/eload_ingestion.py
+++ b/eva_submission/eload_ingestion.py
@@ -358,6 +358,7 @@ class EloadIngestion(Eload):
             })
         load_config = {
             'valid_vcfs': vcf_files_to_ingest,
+            'aggregation_type': self.eload_cfg.query(self.config_section, 'aggregation'),
             'load_job_props': job_props,
             'project_accession': self.project_accession,
             'project_dir': str(self.project_dir),

--- a/eva_submission/ingestion_templates.py
+++ b/eva_submission/ingestion_templates.py
@@ -89,4 +89,5 @@ def variant_load_props_template(
         'annotation.skip': annotation_skip,
         'annotation.overwrite': False,
         'config.chunk.size': 200,
+        'spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation': True,
     }

--- a/eva_submission/nextflow/variant_load.nf
+++ b/eva_submission/nextflow/variant_load.nf
@@ -107,7 +107,7 @@ process create_properties {
     params.load_job_props.each { k, v ->
         props.setProperty(k, v.toString())
     }
-    props.setProperty("input.vcf", vcf_file.toString())
+    props.setProperty("input.vcf", vcf_file.toRealPath().toString())
     props.setProperty("input.vcf.id", analysis_accession.toString())
     props.setProperty("input.fasta", fasta.toString())
     props.setProperty("spring.data.mongodb.database", db_name.toString())

--- a/eva_submission/nextflow/variant_load.nf
+++ b/eva_submission/nextflow/variant_load.nf
@@ -72,21 +72,23 @@ process merge_vcfs {
     input:
     tuple vcf_files, file_count, fasta, analysis_accession, db_name from vcfs_to_merge
     output:
-    tuple "${params.project_accession}_${analysis_accession}_merged.vcf.gz", fasta, analysis_accession, db_name into merged_vcf
+    tuple "${merged_filename}", fasta, analysis_accession, db_name into merged_vcf
 
     script:
+    merged_filename = "${params.project_accession}_${analysis_accession}_merged.vcf.gz"
     if (file_count > 1) {
-        file_list = new File("${workflow.workDir}/all_files_${analysis_accession}.list")
+        list_filename = "${workflow.workDir}/all_files_${analysis_accession}.list"
+        file_list = new File(list_filename)
         file_list.newWriter().withWriter{ w ->
             vcf_files.each { file -> w.write("$file\n")}
         }
         """
-        $params.executable.bcftools merge --merge all --file-list ${workflow.workDir}/all_files_${analysis_accession}.list --threads 3 -O z -o ${params.project_accession}_${analysis_accession}_merged.vcf.gz
+        $params.executable.bcftools merge --merge all --file-list ${list_filename} --threads 3 -O z -o ${merged_filename}
         """
     } else {
         single_file = vcf_files[0]
         """
-        ln -sfT ${single_file} ${params.project_accession}_${analysis_accession}_merged.vcf.gz
+        ln -sfT ${single_file} ${merged_filename}
         """
     }
 }

--- a/tests/nextflow-tests/test_ingestion_config.yaml
+++ b/tests/nextflow-tests/test_ingestion_config.yaml
@@ -9,10 +9,13 @@ accession_job_props:
   test.prop1: x
   test.prop2: y
   parameters.taxonomyAccession: 1234
+needs_merge: true
 eva_pipeline_props: test_eva_pipeline.properties
 load_job_props:
   test.prop1: a
   test.prop2: b
+
+aggregation_type: none
 
 executable:
   bcftools: ../../../bin/fake_bcftools.sh

--- a/tests/nextflow-tests/test_ingestion_config_human.yaml
+++ b/tests/nextflow-tests/test_ingestion_config_human.yaml
@@ -9,10 +9,13 @@ accession_job_props:
   test.prop1: x
   test.prop2: y
   parameters.taxonomyAccession: 9606
+needs_merge: true
 eva_pipeline_props: test_eva_pipeline.properties
 load_job_props:
   test.prop1: a
   test.prop2: b
+
+aggregation_type: none
 
 executable:
   bcftools: ../../../bin/fake_bcftools.sh


### PR DESCRIPTION
* Reinstate merge during ingestion for backwards compatibility (compare [this commit](https://github.com/apriltuesday/eva-submission/commit/b5d2a29942d6ef3e80a1b176e8114beedc125228))
* Follow vcf path symlinks to ensure Spring resumes jobs appropriately
* Add property for variant load pipeline to avoid an exception after Spring upgrade (this was added to the accessioning properties but missed for variant load)