### PR TITLE
EVA-2603 - Download VEP cache base on assembly instead of taxonomy

### DIFF
--- a/bin/ingest_submission.py
+++ b/bin/ingest_submission.py
@@ -32,6 +32,10 @@ def main():
     argparse.add_argument('--tasks', required=False, type=str, nargs='+',
                           default=EloadIngestion.all_tasks, choices=EloadIngestion.all_tasks,
                           help='Task or set of tasks to perform during ingestion.')
+    argparse.add_argument('--vep_cache_assembly_name', required=False, type=str,
+                          help='The assembly name used in the VEP cache to help the script to find the correct cache '
+                               'to use. This should be only used rarely when the script cannot find the VEP cache but '
+                               'we know it exists.')
     argparse.add_argument('--debug', action='store_true', default=False,
                           help='Set the script to output logging information at debug level.')
 
@@ -48,7 +52,8 @@ def main():
     ingestion.upgrade_config_if_needed()
     ingestion.ingest(
         instance_id=args.instance,
-        tasks=args.tasks
+        tasks=args.tasks,
+        vep_cache_assembly_name=args.vep_cache_assembly_name
     )
 
 

--- a/bin/prepare_backlog_study.py
+++ b/bin/prepare_backlog_study.py
@@ -66,6 +66,8 @@ def main():
         for validation_task in forced_validation_tasks:
             validation.eload_cfg.set('validation', validation_task, 'forced', value=True)
         validation.mark_valid_files_and_metadata(args.merge_per_analysis)
+        if args.merge_per_analysis:
+            preparation.copy_valid_config_to_brokering_after_merge()
 
     preparation.report()
     validation.report()

--- a/bin/prepare_backlog_study.py
+++ b/bin/prepare_backlog_study.py
@@ -28,6 +28,7 @@ logger = log_cfg.get_logger(__name__)
 
 def main():
     validation_tasks = ['aggregation_check', 'assembly_check', 'vcf_check']
+    forced_validation_tasks = ['metadata_check', 'sample_check']
 
     argparse = ArgumentParser(description='Prepare to process backlog study and validate VCFs.')
     argparse.add_argument('--eload', required=True, type=int, help='The ELOAD number for this submission')
@@ -36,6 +37,8 @@ def main():
     argparse.add_argument('--validation_tasks', required=False, type=str, nargs='+',
                           default=validation_tasks, choices=validation_tasks,
                           help='task or set of tasks to perform during validation')
+    argparse.add_argument('--merge_per_analysis', action='store_true', default=False,
+                          help='Whether to merge vcf files per analysis if possible.')
     argparse.add_argument('--report', action='store_true', default=False,
                           help='Set the script to only report the results based on previously run preparation.')
     argparse.add_argument('--debug', action='store_true', default=False,
@@ -59,6 +62,10 @@ def main():
     validation = EloadValidation(args.eload)
     if not args.report:
         validation.validate(args.validation_tasks)
+        # Also mark the other validation tasks as force so they are all passable
+        for validation_task in forced_validation_tasks:
+            validation.eload_cfg.set('validation', validation_task, 'forced', value=True)
+        validation.mark_valid_files_and_metadata(args.merge_per_analysis)
 
     preparation.report()
     validation.report()

--- a/bin/update_metadata_post_ingestion.py
+++ b/bin/update_metadata_post_ingestion.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+# Copyright 2020 EMBL - European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from argparse import ArgumentParser
+
+from ebi_eva_common_pyutils.logger import logging_config as log_cfg
+from eva_submission.eload_ingestion import EloadIngestion
+from eva_submission.submission_config import load_config
+
+logger = log_cfg.get_logger(__name__)
+
+
+def main():
+    argparse = ArgumentParser(description='Accession and ingest submission data into EVA')
+    argparse.add_argument('--eload', required=True, type=int, help='The ELOAD number for this submission.')
+    argparse.add_argument('--debug', action='store_true', default=False,
+                          help='Set the script to output logging information at debug level.')
+
+    args = argparse.parse_args()
+
+    log_cfg.add_stdout_handler()
+    if args.debug:
+        log_cfg.set_log_level(logging.DEBUG)
+
+    # Load the config_file from default location
+    load_config()
+
+    ingestion = EloadIngestion(args.eload)
+    ingestion.upgrade_config_if_needed()
+
+    ingestion.insert_browsable_files()
+    ingestion.update_browsable_files_with_date()
+    ingestion.update_files_with_ftp_path()
+    ingestion.refresh_study_browser()
+    ingestion.update_loaded_assembly_in_browsable_files()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/update_metadata_post_ingestion.py
+++ b/bin/update_metadata_post_ingestion.py
@@ -25,7 +25,7 @@ logger = log_cfg.get_logger(__name__)
 
 
 def main():
-    argparse = ArgumentParser(description='Accession and ingest submission data into EVA')
+    argparse = ArgumentParser(description='Update metadata after study has been ingested')
     argparse.add_argument('--eload', required=True, type=int, help='The ELOAD number for this submission.')
     argparse.add_argument('--debug', action='store_true', default=False,
                           help='Set the script to output logging information at debug level.')

--- a/bin/update_metadata_post_ingestion.py
+++ b/bin/update_metadata_post_ingestion.py
@@ -41,7 +41,7 @@ def main():
 
     ingestion = EloadIngestion(args.eload)
     ingestion.upgrade_config_if_needed()
-
+    ingestion.update_assembly_set_in_analysis()
     ingestion.insert_browsable_files()
     ingestion.update_browsable_files_with_date()
     ingestion.update_files_with_ftp_path()

--- a/eva_submission/eload_backlog.py
+++ b/eva_submission/eload_backlog.py
@@ -167,3 +167,10 @@ Analysis accession(s): {analyses}
 Analysis information: {analyses_report}
 """
         print(report.format(**report_data))
+
+
+    def copy_valid_config_to_brokering(self):
+        for analysis_alias, analysis_data in  self.eload_cfg.query('validation', 'valid', 'analyses'):
+            self.eload_cfg.query('validation', 'valid', 'analyses', alias, 'vcf_files', value=[merged_file])
+        self.eload_cfg.set('brokering', 'analyses', analysis_alias, 'vcf_files', 'index',
+                           value=index_file_dict.pop(basename))

--- a/eva_submission/eload_backlog.py
+++ b/eva_submission/eload_backlog.py
@@ -140,6 +140,27 @@ class EloadBacklog(Eload):
             # ingestion
             self.eload_cfg.set('submission', 'analyses', analysis_accession, 'vcf_files', value=vcf_file_list)
 
+    def copy_valid_config_to_brokering_after_merge(self):
+        """
+        Convert the valid entry in the config to the one that should be created after brokering.
+        This is only useful after we merged the vcf files otherwise this function will not do anything.
+        """
+        for analysis_alias, analysis_data in  self.eload_cfg.query('validation', 'valid', 'analyses'):
+            self.eload_cfg.set('brokering', 'analyses', analysis_alias, 'assembly_accession',
+                               value=analysis_data.get('assembly_accession'))
+            self.eload_cfg.set('brokering', 'analyses', analysis_alias, 'assembly_fasta',
+                               value=analysis_data.get('assembly_fasta'))
+            self.eload_cfg.set('brokering', 'analyses', analysis_alias, 'assembly_report',
+                               value=analysis_data.get('assembly_report'))
+            vcf_files_dict = {}
+            for vcf_file in analysis_data.get('vcf_files'):
+                vcf_files_dict[vcf_file] = {}
+                if os.path.exists(vcf_file + '.tbi'):
+                    vcf_files_dict[vcf_file]['index'] = vcf_file + '.tbi'
+                else:
+                    self.warning(f'Cannot find the index for {vcf_file}')
+            self.eload_cfg.set('brokering', 'analyses', analysis_alias, 'vcf_files', value=vcf_files_dict)
+
     def _analysis_report(self, all_analysis):
         reports = []
         for analysis_accession in all_analysis:
@@ -158,7 +179,7 @@ class EloadBacklog(Eload):
         report_data = {
             'project': self.eload_cfg.query('brokering', 'ena', 'PROJECT', ret_default=''),
             'analyses': ', '.join(self.eload_cfg.query('brokering', 'ena', 'ANALYSIS', ret_default=[])),
-            'analyses_report': self._analysis_report(self.eload_cfg.query('submission', 'analyses', ret_default=[]))
+            'analyses_report': self._analysis_report(self.eload_cfg.query('brokering', 'analyses', ret_default=[]))
         }
 
         report = """Results of backlog study preparation:
@@ -167,10 +188,3 @@ Analysis accession(s): {analyses}
 Analysis information: {analyses_report}
 """
         print(report.format(**report_data))
-
-
-    def copy_valid_config_to_brokering(self):
-        for analysis_alias, analysis_data in  self.eload_cfg.query('validation', 'valid', 'analyses'):
-            self.eload_cfg.query('validation', 'valid', 'analyses', alias, 'vcf_files', value=[merged_file])
-        self.eload_cfg.set('brokering', 'analyses', analysis_alias, 'vcf_files', 'index',
-                           value=index_file_dict.pop(basename))

--- a/eva_submission/eload_ingestion.py
+++ b/eva_submission/eload_ingestion.py
@@ -440,10 +440,10 @@ class EloadIngestion(Eload):
         with self.metadata_connection_handle as conn:
             for analysis_alias, analysis_data in analyses.items():
                 assembly_accession = analysis_data['assembly_accession']
-                assembly_set = get_assembly_set(conn, taxonomy, assembly_accession)
+                assembly_set_id = get_assembly_set(conn, taxonomy, assembly_accession)
                 analysis_accession = self.eload_cfg.query('brokering', 'ena', 'ANALYSIS', analysis_alias)
                 analysis_update = (f"update evapro.analysis "
-                                   f"set assembly_set = '{assembly_set}' "
+                                   f"set assembly_set_id = '{assembly_set_id}' "
                                    f"where analysis_accession = '{analysis_accession}';")
                 execute_query(conn, analysis_update)
 

--- a/eva_submission/eload_ingestion.py
+++ b/eva_submission/eload_ingestion.py
@@ -449,7 +449,7 @@ class EloadIngestion(Eload):
                 res = get_all_results_for_query(conn, check_query)
                 if res and res[0][0] != assembly_set_id:
                     if res[0][0]:
-                        self.error(f'Previous assembly_set_id {res[0][0]} fpr {analysis_accession} was wrong and '
+                        self.error(f'Previous assembly_set_id {res[0][0]} for {analysis_accession} was wrong and '
                                    f'will be updated to {assembly_set_id}')
                     analysis_update = (f"update evapro.analysis "
                                        f"set assembly_set_id = '{assembly_set_id}' "

--- a/eva_submission/eload_ingestion.py
+++ b/eva_submission/eload_ingestion.py
@@ -45,7 +45,8 @@ class EloadIngestion(Eload):
     def ingest(
             self,
             instance_id=None,
-            tasks=None
+            tasks=None,
+            vep_cache_assembly_name=None
     ):
         self.eload_cfg.set(self.config_section, 'ingestion_date', value=self.now)
         self.project_dir = self.setup_project_dir()
@@ -65,7 +66,7 @@ class EloadIngestion(Eload):
         do_variant_load = 'variant_load' in tasks
 
         if do_accession or do_variant_load:
-            self.fill_vep_versions()
+            self.fill_vep_versions(vep_cache_assembly_name)
             vcf_files_to_ingest = self._generate_csv_mappings_to_ingest()
 
         if do_accession:
@@ -83,7 +84,7 @@ class EloadIngestion(Eload):
             shutil.rmtree(output_dir)
             self.update_loaded_assembly_in_browsable_files()
 
-    def fill_vep_versions(self):
+    def fill_vep_versions(self, vep_cache_assembly_name=None):
         analyses = self.eload_cfg.query('brokering', 'analyses')
         for analysis_alias, analysis_data in analyses.items():
             assembly_accession = analysis_data['assembly_accession']
@@ -93,7 +94,8 @@ class EloadIngestion(Eload):
             vep_version, vep_cache_version, vep_species = get_vep_and_vep_cache_version(
                 self.mongo_uri,
                 self.eload_cfg.query(self.config_section, 'database', assembly_accession, 'db_name'),
-                assembly_accession
+                assembly_accession,
+                vep_cache_assembly_name
             )
             self.eload_cfg.set(self.config_section, 'vep', assembly_accession, 'version', value=vep_version)
             self.eload_cfg.set(self.config_section, 'vep', assembly_accession, 'cache_version', value=vep_cache_version)

--- a/eva_submission/eload_validation.py
+++ b/eva_submission/eload_validation.py
@@ -48,13 +48,17 @@ class EloadValidation(Eload):
             for validation_task in validation_tasks:
                 self.eload_cfg.set('validation', validation_task, 'forced', value=True)
 
+        self.mark_valid_files_and_metadata(merge_per_analysis)
+
+    def mark_valid_files_and_metadata(self, merge_per_analysis):
         if all([
             self.eload_cfg.query('validation', validation_task, 'pass', ret_default=False) or
             self.eload_cfg.query('validation', validation_task, 'forced', ret_default=False)
             for validation_task in self.all_validation_tasks
         ]):
             self.eload_cfg.set('validation', 'valid', 'analyses', value=self.eload_cfg.query('submission', 'analyses'))
-            self.eload_cfg.set('validation', 'valid', 'metadata_spreadsheet', value=self.eload_cfg['submission']['metadata_spreadsheet'])
+            self.eload_cfg.set('validation', 'valid', 'metadata_spreadsheet',
+                               value=self.eload_cfg.query('submission', 'metadata_spreadsheet'))
             self.detect_and_optionally_merge(merge_per_analysis)
 
     def _get_vcf_files(self):

--- a/eva_submission/ingestion_templates.py
+++ b/eva_submission/ingestion_templates.py
@@ -54,8 +54,7 @@ def variant_load_props_template(
         study_name,
         output_dir,
         annotation_dir,
-        stats_dir,
-        vep_species,
+        stats_dir
 ):
     """
     Get all properties needed for this variant load job, except for the vcf file
@@ -73,7 +72,6 @@ def variant_load_props_template(
         'db.collections.annotation-metadata.name': 'annotationMetadata_2_0',
         'db.collections.annotations.name': annotation_collection_name,
         'app.vep.cache.path': cfg['vep_cache_path'],
-        'app.vep.cache.species': vep_species,
         'app.vep.num-forks': 4,
         'app.vep.timeout': 500,
         'statistics.skip': False,

--- a/eva_submission/nextflow/variant_load.nf
+++ b/eva_submission/nextflow/variant_load.nf
@@ -56,7 +56,7 @@ merged and passed directly to create the properties
 vcfs_to_merge = Channel.fromPath(params.valid_vcfs)
             .splitCsv(header:true)
             .filter(row -> row.aggregation.equals("none"))
-            .map{row -> tuple(file(row.vcf_file), file(row.fasta), row.analysis_accession, row.db_name, row.vep_version, row.vep_species, row.vep_cache_version)}
+            .map{row -> tuple(file(row.vcf_file), file(row.fasta), row.analysis_accession, row.db_name, row.vep_version, row.vep_cache_version, row.vep_species)}
             .groupTuple(by:2)
             .map{row -> tuple(row[0], row[0].size(), row[1][0], row[2], row[3][0], row[4][0], row[5][0], row[6][0], "none") }
 

--- a/eva_submission/vep_utils.py
+++ b/eva_submission/vep_utils.py
@@ -27,7 +27,7 @@ ensembl_genome_dirs = [
 ]
 
 # Name of collection in variant warehouse to check for existing VEP versions
-annotation_collection_name = 'annotations_2_0'
+annotation_collection_name = 'annotationMetadata_2_0'
 
 
 def vep_path(version):

--- a/eva_submission/vep_utils.py
+++ b/eva_submission/vep_utils.py
@@ -34,14 +34,16 @@ def vep_path(version):
     return os.path.join(cfg['vep_path'], f'ensembl-vep-release-{version}/vep')
 
 
-def get_vep_and_vep_cache_version(mongo_uri, db_name, assembly_accession):
+def get_vep_and_vep_cache_version(mongo_uri, db_name, assembly_accession, vep_cache_assembly_name=None):
     """
     Gets VEP and VEP cache versions for a given assembly by first checking what is already in the variant DB,
     then checking Ensembl and Ensembl Genome FTPs, otherwise returns None.
     """
     vep_version, vep_cache_version = get_vep_and_vep_cache_version_from_db(mongo_uri, db_name)
     if not vep_cache_version and not vep_version:
-        vep_version, vep_cache_version, vep_species = get_vep_and_vep_cache_version_from_ensembl(assembly_accession)
+        vep_version, vep_cache_version, vep_species = get_vep_and_vep_cache_version_from_ensembl(
+            assembly_accession, ensembl_assembly_name=vep_cache_assembly_name
+        )
     else:
         vep_species, _, _ = get_species_and_assembly(assembly_accession)
     if check_vep_version_installed(vep_version):

--- a/eva_submission/vep_utils.py
+++ b/eva_submission/vep_utils.py
@@ -185,7 +185,6 @@ def get_releases(ftp, subdir, current_only):
 def search_releases(ftp, all_releases, species, assembly):
     for release in sorted(all_releases, reverse=True):
         logger.info(f'Looking for vep_cache_version in release : {all_releases[release]}')
-        print(f'Looking for vep_cache_version in release : {all_releases[release]}')
         all_species_files = get_all_species_files(ftp, all_releases.get(release))
         for f in all_species_files:
             if species in f and assembly in f:

--- a/tests/nextflow-tests/vcf_files_to_ingest.csv
+++ b/tests/nextflow-tests/vcf_files_to_ingest.csv
@@ -1,4 +1,4 @@
-vcf_file,assembly_accession,fasta,report,analysis_accession,db_name,vep_version,vep_cache_version,aggregation
-vcfs/test1.vcf.gz,GCA_000001000.1,fasta.fa,assembly_report.txt,ERZ12345,db1,100,100,none
-vcfs/test2.vcf.gz,GCA_000001000.1,fasta.fa,assembly_report.txt,ERZ12345,db1,100,100,none
-vcfs/test3.vcf.gz,GCA_000001000.1,fasta.fa,assembly_report.txt,ERZ12346,db2,,,none
+vcf_file,assembly_accession,fasta,report,analysis_accession,db_name,vep_version,vep_cache_version,vep_secies,aggregation
+vcfs/test1.vcf.gz,GCA_000001000.1,fasta.fa,assembly_report.txt,ERZ12345,db1,100,100,homo_sapiens,none
+vcfs/test2.vcf.gz,GCA_000001000.1,fasta.fa,assembly_report.txt,ERZ12345,db1,100,100,homo_sapiens,none
+vcfs/test3.vcf.gz,GCA_000001000.1,fasta.fa,assembly_report.txt,ERZ12346,db2,,,,none

--- a/tests/resources/eloads/ELOAD_33/.ELOAD_33_config.yml
+++ b/tests/resources/eloads/ELOAD_33/.ELOAD_33_config.yml
@@ -13,7 +13,7 @@ brokering:
           index: tests/resources/eloads/ELOAD_33/18_brokering/ena/test2.vcf.gz.tbi
   ena:
     ANALYSIS:
-      ERZ2499196: Analysis alias test
+      Analysis alias test: ERZ2499196
     PROJECT: PRJEB12345
     hold_date: 2021-01-04
 ingestion:

--- a/tests/test_eload_ingestion.py
+++ b/tests/test_eload_ingestion.py
@@ -126,6 +126,7 @@ class TestEloadIngestion(TestCase):
             m_get_vep_versions.return_value = (100, 100, 'homo_sapiens')
             m_post.return_value.text = self.get_mock_result_for_ena_date()
             m_get_results.side_effect = [
+                [(391,)],                                # Check the assembly_set_id in update_assembly_set_in_analysis
                 [(1, 'filename_1'), (2, 'filename_2')],  # insert_browsable_files
                 [(1, 'filename_1'), (2, 'filename_2')],  # update_files_with_ftp_path
                 [('Test Study Name')],                   # get_study_name

--- a/tests/test_vep_utils.py
+++ b/tests/test_vep_utils.py
@@ -61,13 +61,13 @@ drwxrwxr-x    2 ftp      ftp        102400 Apr 13 13:59 2_collection
         )
 
     def test_get_vep_versions_from_ensembl(self):
-        vep_version, cache_version = get_vep_and_vep_cache_version_from_ensembl('fake_db', 669202, 'GCA_000827895.1')
+        vep_version, cache_version = get_vep_and_vep_cache_version_from_ensembl('fake_db', 'GCA_000827895.1')
         self.assertEqual(vep_version, 104)
         self.assertEqual(cache_version, 51)
         assert os.path.exists(os.path.join(cfg['vep_cache_path'], 'thelohanellus_kitauei'))
 
     def test_get_vep_versions_from_ensembl_not_found(self):
-        vep_version, cache_version = get_vep_and_vep_cache_version_from_ensembl('fake_db', 27675, 'GCA_015220235.1')
+        vep_version, cache_version = get_vep_and_vep_cache_version_from_ensembl('fake_db', 'GCA_015220235.1')
         self.assertEqual(vep_version, None)
         self.assertEqual(cache_version, None)
 

--- a/tests/test_vep_utils.py
+++ b/tests/test_vep_utils.py
@@ -77,13 +77,11 @@ drwxrwxr-x    2 ftp      ftp        102400 Apr 13 13:59 2_collection
 
     # DISABLED because too slow and make deployment difficult.
     # def test_get_vep_versions_from_ensembl_older_version(self):
-    #     logging_config.set_log_level(logging.INFO)
     #     # Older version of assembly using NCBI assembly code isn't found successfully
     #     # TODO this takes about 20 minutes to finish when I test locally
     #     vep_version, cache_version, vep_species = get_vep_and_vep_cache_version_from_ensembl('GCA_000002765.1')
     #     self.assertEqual(vep_version, None)
     #     self.assertEqual(cache_version, None)
-    #
     #     # If we magically knew the Ensembl assembly code was EPr1 we could find it!
     #     vep_version, cache_version, vep_species = get_vep_and_vep_cache_version_from_ensembl('GCA_000002765.1', 'EPr1')
     #     self.assertEqual(vep_version, 44 + 53)


### PR DESCRIPTION
This also means that the VEP species is analysis specific. 
This PR also add: 
 - a function to load assembly_set_id which is sometime missing
 - the ability to merge VCF files during backlog preparation
 - a new script that only runs queries on the metadata database
