### PR TITLE
Fix brokering prep

### DIFF
--- a/eva_submission/eload_brokering.py
+++ b/eva_submission/eload_brokering.py
@@ -39,7 +39,7 @@ class EloadBrokering(Eload):
         self.broker_to_ena(force=('ena' in brokering_tasks_to_force), existing_project=existing_project)
 
     def prepare_brokering(self, force=False):
-        if not self.eload_cfg.query('brokering', 'vcf_files') or force:
+        if not self.eload_cfg.query('brokering', 'analyses', 'vcf_files') or force:
             output_dir = self._run_brokering_prep_workflow()
             self._collect_brokering_prep_results(output_dir)
             shutil.rmtree(output_dir)


### PR DESCRIPTION
Prevent restarting the brokering preparation when it has already been performed
This must have been broken when we switched to multiple analysis