### PR TITLE
EVA-2404 - Resumable ingestion

### DIFF
--- a/bin/ingest_submission.py
+++ b/bin/ingest_submission.py
@@ -36,6 +36,8 @@ def main():
                           help='The assembly name used in the VEP cache to help the script to find the correct cache '
                                'to use. This should be only used rarely when the script cannot find the VEP cache but '
                                'we know it exists.')
+    argparse.add_argument('--resume', action='store_true', default=False,
+                          help='Whether to resume an existing Nextflow process within ingestion.')
     argparse.add_argument('--debug', action='store_true', default=False,
                           help='Set the script to output logging information at debug level.')
 
@@ -53,7 +55,8 @@ def main():
     ingestion.ingest(
         instance_id=args.instance,
         tasks=args.tasks,
-        vep_cache_assembly_name=args.vep_cache_assembly_name
+        vep_cache_assembly_name=args.vep_cache_assembly_name,
+        resume=args.resume
     )
 
 

--- a/eva_submission/eload_ingestion.py
+++ b/eva_submission/eload_ingestion.py
@@ -47,7 +47,8 @@ class EloadIngestion(Eload):
             self,
             instance_id=None,
             tasks=None,
-            vep_cache_assembly_name=None
+            vep_cache_assembly_name=None,
+            resume=False
     ):
         self.eload_cfg.set(self.config_section, 'ingestion_date', value=self.now)
         self.project_dir = self.setup_project_dir()
@@ -74,16 +75,14 @@ class EloadIngestion(Eload):
         if do_accession:
             self.eload_cfg.set(self.config_section, 'accession', 'instance_id', value=instance_id)
             self.update_config_with_hold_date(self.project_accession)
-            output_dir = self.run_accession_workflow(vcf_files_to_ingest)
-            shutil.rmtree(output_dir)
+            self.run_accession_workflow(vcf_files_to_ingest, resume=resume)
             self.insert_browsable_files()
             self.update_browsable_files_with_date()
             self.update_files_with_ftp_path()
             self.refresh_study_browser()
 
         if do_variant_load or annotation_only:
-            output_dir = self.run_variant_load_workflow(vcf_files_to_ingest, annotation_only)
-            shutil.rmtree(output_dir)
+            self.run_variant_load_workflow(vcf_files_to_ingest, annotation_only, resume=resume)
             self.update_loaded_assembly_in_browsable_files()
 
     def fill_vep_versions(self, vep_cache_assembly_name=None):
@@ -286,8 +285,7 @@ class EloadIngestion(Eload):
                     self.warning(f"VCF files for analysis {analysis_alias} not found")
         return vcf_files_to_ingest
 
-    def run_accession_workflow(self, vcf_files_to_ingest):
-        output_dir = self.create_nextflow_temp_output_directory(base=self.project_dir)
+    def run_accession_workflow(self, vcf_files_to_ingest, resume):
         mongo_host, mongo_user, mongo_pass = get_primary_mongo_creds_for_profile(cfg['maven']['environment'], cfg['maven']['settings_file'])
         pg_url, pg_user, pg_pass = get_accession_pg_creds_for_profile(cfg['maven']['environment'], cfg['maven']['settings_file'])
         counts_url, counts_user, counts_pass = get_count_service_creds_for_profile(cfg['maven']['environment'], cfg['maven']['settings_file'])
@@ -317,29 +315,9 @@ class EloadIngestion(Eload):
             'executable': cfg['executable'],
             'jar': cfg['jar'],
         }
-        accession_config_file = os.path.join(self.project_dir, 'accession_config_file.yaml')
-        with open(accession_config_file, 'w') as open_file:
-            yaml.safe_dump(accession_config, open_file)
-        accession_script = os.path.join(NEXTFLOW_DIR, 'accession.nf')
-        try:
-            command_utils.run_command_with_output(
-                'Nextflow Accessioning process',
-                ' '.join((
-                    'export NXF_OPTS="-Xms1g -Xmx8g"; ',
-                    cfg['executable']['nextflow'], accession_script,
-                    '-params-file', accession_config_file,
-                    '-work-dir', output_dir
-                ))
-            )
-        except subprocess.CalledProcessError as e:
-            self.error('Nextflow accessioning pipeline failed: results might not be complete.')
-            self.error(f"See Nextflow logs in {self.eload_dir}/.nextflow.log or accessioning logs "
-                       f"in {self.project_dir.joinpath(project_dirs['logs'])} for more details.")
-            raise e
-        return output_dir
+        self.run_nextflow('accession', accession_config, resume)
 
-    def run_variant_load_workflow(self, vcf_files_to_ingest, annotation_only):
-        output_dir = self.create_nextflow_temp_output_directory(base=self.project_dir)
+    def run_variant_load_workflow(self, vcf_files_to_ingest, annotation_only, resume):
         job_props = variant_load_props_template(
                 project_accession=self.project_accession,
                 study_name=self.get_study_name(),
@@ -359,26 +337,7 @@ class EloadIngestion(Eload):
             'jar': cfg['jar'],
             'annotation_only': annotation_only,
         }
-        load_config_file = os.path.join(self.project_dir, 'load_config_file.yaml')
-        with open(load_config_file, 'w') as open_file:
-            yaml.safe_dump(load_config, open_file)
-        variant_load_script = os.path.join(NEXTFLOW_DIR, 'variant_load.nf')
-        try:
-            command_utils.run_command_with_output(
-                'Nextflow Variant Load process',
-                ' '.join((
-                    'export NXF_OPTS="-Xms1g -Xmx8g"; ',
-                    cfg['executable']['nextflow'], variant_load_script,
-                    '-params-file', load_config_file,
-                    '-work-dir', output_dir
-                ))
-            )
-        except subprocess.CalledProcessError as e:
-            self.error('Nextflow variant load pipeline failed: results might not be complete')
-            self.error(f"See Nextflow logs in {self.eload_dir}/.nextflow.log or pipeline logs "
-                       f"in {self.project_dir.joinpath(project_dirs['logs'])} for more details.")
-            raise e
-        return output_dir
+        self.run_nextflow('variant_load', load_config, resume)
 
     def insert_browsable_files(self):
         with self.metadata_connection_handle as conn:
@@ -479,3 +438,37 @@ class EloadIngestion(Eload):
     @cached_property
     def valid_vcf_filenames(self):
         return list(self.project_dir.joinpath(project_dirs['valid']).glob('*.vcf.gz'))
+
+    def run_nextflow(self, workflow_name, params, resume):
+        work_dir = None
+        if resume:
+            work_dir = self.eload_cfg.query(self.config_section, workflow_name, 'nextflow_dir')
+        if not resume or not work_dir:
+            work_dir = self.create_nextflow_temp_output_directory(base=self.project_dir)
+            self.eload_cfg.set(self.config_section, workflow_name, 'nextflow_dir', value=work_dir)
+
+        params_file = os.path.join(self.project_dir, f'{workflow_name}_params.yaml')
+        with open(params_file, 'w') as open_file:
+            yaml.safe_dump(params, open_file)
+        nextflow_script = os.path.join(NEXTFLOW_DIR, f'{workflow_name}.nf')
+
+        try:
+            command_utils.run_command_with_output(
+                f'Nextflow {workflow_name} process',
+                ' '.join((
+                    'export NXF_OPTS="-Xms1g -Xmx8g"; ',
+                    cfg['executable']['nextflow'], nextflow_script,
+                    '-params-file', params_file,
+                    '-work-dir', work_dir,
+                    '-resume' if resume else ''
+                ))
+            )
+            # TODO only do this at the end of the entire process (ensures completed NF process won't re-run)
+            shutil.rmtree(work_dir)
+            self.eload_cfg.pop(self.config_section, str(workflow_name), 'nextflow_dir')
+        except subprocess.CalledProcessError as e:
+            error_msg = f'Nextflow {workflow_name} pipeline failed: results might not be complete.'
+            error_msg += (f"See Nextflow logs in {self.eload_dir}/.nextflow.log or pipeline logs "
+                          f"in {self.project_dir.joinpath(project_dirs['logs'])} for more details.")
+            self.error(error_msg)
+            raise e

--- a/eva_submission/eload_ingestion.py
+++ b/eva_submission/eload_ingestion.py
@@ -463,7 +463,6 @@ class EloadIngestion(Eload):
                     '-resume' if resume else ''
                 ))
             )
-            # TODO only do this at the end of the entire process (ensures completed NF process won't re-run)
             shutil.rmtree(work_dir)
             self.eload_cfg.pop(self.config_section, str(workflow_name), 'nextflow_dir')
         except subprocess.CalledProcessError as e:

--- a/tests/nextflow-tests/test_ingestion_config.yaml
+++ b/tests/nextflow-tests/test_ingestion_config.yaml
@@ -10,7 +10,6 @@ accession_job_props:
   test.prop1: x
   test.prop2: y
   parameters.taxonomyAccession: 1234
-needs_merge: true
 eva_pipeline_props: test_eva_pipeline.properties
 load_job_props:
   test.prop1: a

--- a/tests/nextflow-tests/test_ingestion_config_human.yaml
+++ b/tests/nextflow-tests/test_ingestion_config_human.yaml
@@ -10,7 +10,6 @@ accession_job_props:
   test.prop1: x
   test.prop2: y
   parameters.taxonomyAccession: 9606
-needs_merge: true
 eva_pipeline_props: test_eva_pipeline.properties
 load_job_props:
   test.prop1: a

--- a/tests/resources/settings.xml
+++ b/tests/resources/settings.xml
@@ -1,0 +1,21 @@
+<settings>
+    <profiles>
+        <profile>
+            <id>internal</id>
+            <properties>
+                <eva.mongo.host>host</eva.mongo.host>
+                <eva.mongo.user>user</eva.mongo.user>
+                <eva.mongo.passwd>pass</eva.mongo.passwd>
+                <eva.count-stats.url>host</eva.count-stats.url>
+                <eva.count-stats.username>user</eva.count-stats.username>
+                <eva.count-stats.password>pass</eva.count-stats.password>
+                <eva.evapro.jdbc.url>host</eva.evapro.jdbc.url>
+                <eva.evapro.user>user</eva.evapro.user>
+                <eva.evapro.password>pass</eva.evapro.password>
+                <eva.accession.jdbc.url>host</eva.accession.jdbc.url>
+                <eva.accession.user>user</eva.accession.user>
+                <eva.accession.password>pass</eva.accession.password>
+            </properties>
+        </profile>
+    </profiles>
+</settings>

--- a/tests/resources/submission_config.yml
+++ b/tests/resources/submission_config.yml
@@ -11,7 +11,7 @@ genome_downloader:
 
 maven:
   environment: 'internal'
-  settings_file: 'path/to/settings/file'
+  settings_file: 'tests/resources/settings.xml'
 
 mongodb:
   mongo_admin_uri: mongodb://username@mongo-server.example.com:27017

--- a/tests/test_eload_ingestion.py
+++ b/tests/test_eload_ingestion.py
@@ -108,12 +108,6 @@ class TestEloadIngestion(TestCase):
 
     def test_ingest_all_tasks(self):
         with self._patch_metadata_handle(), \
-                patch('eva_submission.eload_ingestion.get_primary_mongo_creds_for_profile',
-                      autospec=True) as m_mongo_creds, \
-                patch('eva_submission.eload_ingestion.get_accession_pg_creds_for_profile',
-                      autospec=True) as m_pg_creds, \
-                patch('eva_submission.eload_ingestion.get_count_service_creds_for_profile',
-                      autospec=True) as m_counts_creds, \
                 patch('eva_submission.eload_ingestion.get_all_results_for_query') as m_get_results, \
                 patch('eva_submission.eload_ingestion.command_utils.run_command_with_output', autospec=True), \
                 patch('eva_submission.eload_utils.get_metadata_connection_handle', autospec=True), \
@@ -121,7 +115,6 @@ class TestEloadIngestion(TestCase):
                 patch('eva_submission.eload_ingestion.get_vep_and_vep_cache_version') as m_get_vep_versions, \
                 patch('eva_submission.eload_utils.requests.post') as m_post, \
                 self._patch_mongo_database():
-            m_mongo_creds.return_value = m_pg_creds.return_value = m_counts_creds.return_value = ('host', 'user', 'pass')
             m_get_alias_results.return_value = [['alias']]
             m_get_vep_versions.return_value = (100, 100, 'homo_sapiens')
             m_post.return_value.text = self.get_mock_result_for_ena_date()
@@ -149,10 +142,6 @@ class TestEloadIngestion(TestCase):
 
     def test_ingest_accession(self):
         with self._patch_metadata_handle(), \
-                patch('eva_submission.eload_ingestion.get_primary_mongo_creds_for_profile',
-                      autospec=True) as m_mongo_creds, \
-                patch('eva_submission.eload_ingestion.get_accession_pg_creds_for_profile', autospec=True) as m_pg_creds, \
-                patch('eva_submission.eload_ingestion.get_count_service_creds_for_profile', autospec=True) as m_counts_creds, \
                 patch('eva_submission.eload_ingestion.get_all_results_for_query') as m_get_results, \
                 patch('eva_submission.eload_ingestion.command_utils.run_command_with_output', autospec=True), \
                 patch('eva_submission.eload_utils.get_metadata_connection_handle', autospec=True), \
@@ -160,7 +149,6 @@ class TestEloadIngestion(TestCase):
                 patch('eva_submission.eload_ingestion.get_vep_and_vep_cache_version') as m_get_vep_versions, \
                 patch('eva_submission.eload_utils.requests.post') as m_post, \
                 self._patch_mongo_database():
-            m_mongo_creds.return_value = m_pg_creds.return_value = m_counts_creds.return_value = ('host', 'user', 'pass')
             m_get_alias_results.return_value = [['alias']]
             m_get_vep_versions.return_value = (100, 100, 'homo_sapiens')
             m_post.return_value.text = self.get_mock_result_for_ena_date()
@@ -170,7 +158,7 @@ class TestEloadIngestion(TestCase):
                 tasks=['accession']
             )
             assert os.path.exists(
-                os.path.join(self.resources_folder, 'projects/PRJEB12345/accession_config_file.yaml')
+                os.path.join(self.resources_folder, 'projects/PRJEB12345/accession_params.yaml')
             )
 
     def test_ingest_variant_load(self):
@@ -188,7 +176,7 @@ class TestEloadIngestion(TestCase):
             m_get_results.side_effect = [[('Test Study Name')], [(1, 'filename_1'), (2, 'filename_2')]]
             self.eload.ingest(tasks=['variant_load'])
             assert os.path.exists(
-                os.path.join(self.resources_folder, 'projects/PRJEB12345/load_config_file.yaml')
+                os.path.join(self.resources_folder, 'projects/PRJEB12345/variant_load_params.yaml')
             )
 
     def test_insert_browsable_files(self):
@@ -319,7 +307,7 @@ class TestEloadIngestion(TestCase):
             m_get_vep_versions.side_effect = ValueError()
             with self.assertRaises(ValueError):
                 self.eload.ingest(tasks=['variant_load'])
-            config_file = os.path.join(self.resources_folder, 'projects/PRJEB12345/load_config_file.yaml')
+            config_file = os.path.join(self.resources_folder, 'projects/PRJEB12345/variant_load_params.yaml')
             assert not os.path.exists(config_file)
 
     def test_ingest_annotation_only(self):
@@ -337,5 +325,5 @@ class TestEloadIngestion(TestCase):
             m_get_results.side_effect = [[('Test Study Name')], [(1, 'filename_1'), (2, 'filename_2')]]
             self.eload.ingest(tasks=['annotation'])
             assert os.path.exists(
-                os.path.join(self.resources_folder, 'projects/PRJEB12345/load_config_file.yaml')
+                os.path.join(self.resources_folder, 'projects/PRJEB12345/variant_load_params.yaml')
             )

--- a/tests/test_eload_ingestion.py
+++ b/tests/test_eload_ingestion.py
@@ -10,6 +10,36 @@ from eva_submission.eload_ingestion import EloadIngestion
 from eva_submission.submission_config import load_config
 
 
+def default_db_results_for_metadata_load():
+    return [
+        [(391,)]  # Check the assembly_set_id in update_assembly_set_in_analysis
+    ]
+
+
+def default_db_results_for_accession():
+    browsable_files = [(1, 'ERA', 'filename_1', 'PRJ', 123), (2, 'ERA', 'filename_1', 'PRJ', 123)]
+    return [
+        browsable_files,  # insert_browsable_files files_query
+        browsable_files,  # insert_browsable_files find_browsable_files_query
+        [(1, 'filename_1'), (2, 'filename_2')]  # update_files_with_ftp_path
+    ]
+
+
+def default_db_results_for_variant_load():
+    return [
+        [('Test Study Name')],  # get_study_name
+        [(1, 'filename_1'), (2, 'filename_2')]  # update_loaded_assembly_in_browsable_files
+    ]
+
+
+def default_db_results_for_ingestion():
+    return (
+            default_db_results_for_metadata_load()
+            + default_db_results_for_accession()
+            + default_db_results_for_variant_load()
+    )
+
+
 class TestEloadIngestion(TestCase):
     top_dir = os.path.dirname(os.path.dirname(__file__))
     resources_folder = os.path.join(os.path.dirname(__file__), 'resources')
@@ -118,15 +148,7 @@ class TestEloadIngestion(TestCase):
             m_get_alias_results.return_value = [['alias']]
             m_get_vep_versions.return_value = (100, 100, 'homo_sapiens')
             m_post.return_value.text = self.get_mock_result_for_ena_date()
-            browsable_files = [(1, 'ERA', 'filename_1', 'PRJ', 123), (2, 'ERA', 'filename_1', 'PRJ', 123)]
-            m_get_results.side_effect = [
-                [(391,)],                                # Check the assembly_set_id in update_assembly_set_in_analysis
-                browsable_files,                         # insert_browsable_files files_query
-                browsable_files,                         # insert_browsable_files find_browsable_files_query
-                [(1, 'filename_1'), (2, 'filename_2')],  # update_files_with_ftp_path
-                [('Test Study Name')],                   # get_study_name
-                [(1, 'filename_1'), (2, 'filename_2')]   # update_loaded_assembly_in_browsable_files
-            ]
+            m_get_results.side_effect = default_db_results_for_ingestion()
             self.eload.ingest(1)
 
     def test_ingest_metadata_load(self):
@@ -152,7 +174,7 @@ class TestEloadIngestion(TestCase):
             m_get_alias_results.return_value = [['alias']]
             m_get_vep_versions.return_value = (100, 100, 'homo_sapiens')
             m_post.return_value.text = self.get_mock_result_for_ena_date()
-            m_get_results.return_value = [(1, 'filename_1'), (2, 'filename_2')]
+            m_get_results.side_effect = default_db_results_for_accession()
             self.eload.ingest(
                 instance_id=1,
                 tasks=['accession']
@@ -173,7 +195,7 @@ class TestEloadIngestion(TestCase):
             m_get_alias_results.return_value = [['alias']]
             m_get_vep_versions.return_value = (100, 100, 'homo_sapiens')
             m_post.return_value.text = self.get_mock_result_for_ena_date()
-            m_get_results.side_effect = [[('Test Study Name')], [(1, 'filename_1'), (2, 'filename_2')]]
+            m_get_results.side_effect = default_db_results_for_variant_load()
             self.eload.ingest(tasks=['variant_load'])
             assert os.path.exists(
                 os.path.join(self.resources_folder, 'projects/PRJEB12345/variant_load_params.yaml')
@@ -264,7 +286,7 @@ class TestEloadIngestion(TestCase):
                 self._patch_mongo_database():
             m_get_alias_results.return_value = [['alias']]
             m_post.return_value.text = self.get_mock_result_for_ena_date()
-            m_get_results.side_effect = [[('Test Study Name')], [(1, 'filename_1'), (2, 'filename_2')]]
+            m_get_results.side_effect = default_db_results_for_variant_load()
             m_get_vep_versions.return_value = (100, 100, 'homo_sapiens')
             self.eload.ingest(tasks=['variant_load'])
             self.assert_vep_versions(100, 100, 'homo_sapiens')
@@ -284,7 +306,7 @@ class TestEloadIngestion(TestCase):
                 self._patch_mongo_database():
             m_get_alias_results.return_value = [['alias']]
             m_post.return_value.text = self.get_mock_result_for_ena_date()
-            m_get_results.side_effect = [[('Test Study Name')], [(1, 'filename_1'), (2, 'filename_2')]]
+            m_get_results.side_effect = default_db_results_for_variant_load()
             m_get_vep_versions.return_value = (None, None, None)
             self.eload.ingest(tasks=['variant_load'])
             self.assert_vep_versions('', '', '')
@@ -303,7 +325,7 @@ class TestEloadIngestion(TestCase):
                 self._patch_mongo_database():
             m_get_alias_results.return_value = [['alias']]
             m_post.return_value.text = self.get_mock_result_for_ena_date()
-            m_get_results.side_effect = [[('Test Study Name')], [(1, 'filename_1'), (2, 'filename_2')]]
+            m_get_results.side_effect = default_db_results_for_variant_load()
             m_get_vep_versions.side_effect = ValueError()
             with self.assertRaises(ValueError):
                 self.eload.ingest(tasks=['variant_load'])
@@ -322,8 +344,101 @@ class TestEloadIngestion(TestCase):
             m_get_alias_results.return_value = [['alias']]
             m_get_vep_versions.return_value = (100, 100, 'homo_sapiens')
             m_post.return_value.text = self.get_mock_result_for_ena_date()
-            m_get_results.side_effect = [[('Test Study Name')], [(1, 'filename_1'), (2, 'filename_2')]]
+            m_get_results.side_effect = default_db_results_for_variant_load()
             self.eload.ingest(tasks=['annotation'])
             assert os.path.exists(
                 os.path.join(self.resources_folder, 'projects/PRJEB12345/variant_load_params.yaml')
             )
+
+    def test_resume_when_step_fails(self):
+        with self._patch_metadata_handle(), \
+                patch('eva_submission.eload_ingestion.get_all_results_for_query') as m_get_results, \
+                patch('eva_submission.eload_ingestion.command_utils.run_command_with_output', autospec=True) as m_run_command, \
+                patch('eva_submission.eload_utils.get_metadata_connection_handle', autospec=True), \
+                patch('eva_submission.eload_utils.get_all_results_for_query') as m_get_alias_results, \
+                patch('eva_submission.eload_ingestion.get_vep_and_vep_cache_version') as m_get_vep_versions, \
+                patch('eva_submission.eload_utils.requests.post') as m_post, \
+                self._patch_mongo_database():
+            m_get_alias_results.return_value = [['alias']]
+            m_get_vep_versions.return_value = (100, 100, 'homo_sapiens')
+            m_post.return_value.text = self.get_mock_result_for_ena_date()
+            m_get_results.side_effect = default_db_results_for_metadata_load() + default_db_results_for_ingestion()
+
+            m_run_command.side_effect = [
+                None,  # metadata load
+                subprocess.CalledProcessError(1, 'nextflow accession'),  # first accession fails
+                None,  # metadata load on resume
+                None,  # accession on resume
+                None,  # variant load
+            ]
+
+            with self.assertRaises(subprocess.CalledProcessError):
+                self.eload.ingest()
+            nextflow_dir = self.eload.eload_cfg.query(self.eload.config_section, 'accession', 'nextflow_dir')
+            assert os.path.exists(nextflow_dir)
+
+            self.eload.ingest(resume=True)
+            assert not os.path.exists(nextflow_dir)
+
+    def test_resume_completed_job(self):
+        with self._patch_metadata_handle(), \
+                patch('eva_submission.eload_ingestion.get_all_results_for_query') as m_get_results, \
+                patch('eva_submission.eload_ingestion.command_utils.run_command_with_output', autospec=True), \
+                patch('eva_submission.eload_utils.get_metadata_connection_handle', autospec=True), \
+                patch('eva_submission.eload_utils.get_all_results_for_query') as m_get_alias_results, \
+                patch('eva_submission.eload_ingestion.get_vep_and_vep_cache_version') as m_get_vep_versions, \
+                patch('eva_submission.eload_utils.requests.post') as m_post, \
+                self._patch_mongo_database():
+            m_get_alias_results.return_value = [['alias']]
+            m_get_vep_versions.return_value = (100, 100, 'homo_sapiens')
+            m_post.return_value.text = self.get_mock_result_for_ena_date()
+            m_get_results.side_effect = default_db_results_for_ingestion() + default_db_results_for_ingestion()
+
+            # Resuming with no existing job execution is fine
+            self.eload.ingest(resume=True)
+            num_calls = m_get_results.call_count
+
+            # If we resume a successfully completed job, everything will re-run
+            self.eload.ingest(resume=True)
+            assert m_get_results.call_count == 2*num_calls
+
+    def test_resume_with_tasks(self):
+        with self._patch_metadata_handle(), \
+                patch('eva_submission.eload_ingestion.get_all_results_for_query') as m_get_results, \
+                patch('eva_submission.eload_ingestion.command_utils.run_command_with_output', autospec=True) as m_run_command, \
+                patch('eva_submission.eload_utils.get_metadata_connection_handle', autospec=True), \
+                patch('eva_submission.eload_utils.get_all_results_for_query') as m_get_alias_results, \
+                patch('eva_submission.eload_ingestion.get_vep_and_vep_cache_version') as m_get_vep_versions, \
+                patch('eva_submission.eload_utils.requests.post') as m_post, \
+                self._patch_mongo_database():
+            m_get_alias_results.return_value = [['alias']]
+            m_get_vep_versions.return_value = (100, 100, 'homo_sapiens')
+            m_post.return_value.text = self.get_mock_result_for_ena_date()
+            m_get_results.side_effect = (
+                    default_db_results_for_variant_load()
+                    + default_db_results_for_accession() + default_db_results_for_variant_load()
+            )
+
+            m_run_command.side_effect = [
+                subprocess.CalledProcessError(1, 'nextflow accession'),  # first accession fails
+                None,  # variant load run alone
+                None,  # accession on resume
+                None,  # variant load on resume
+            ]
+
+            # Accession fails...
+            with self.assertRaises(subprocess.CalledProcessError):
+                self.eload.ingest(tasks=['accession'], resume=True)
+            accession_nextflow_dir = self.eload.eload_cfg.query(self.eload.config_section, 'accession', 'nextflow_dir')
+            assert os.path.exists(accession_nextflow_dir)
+
+            # ...doesn't resume when we run just variant_load...
+            self.eload.ingest(tasks=['variant_load'], resume=True)
+            assert os.path.exists(accession_nextflow_dir)
+            load_nextflow_dir = self.eload.eload_cfg.query(self.eload.config_section, 'variant_load', 'nextflow_dir')
+            assert not os.path.exists(load_nextflow_dir)
+
+            # ...and does resume when we run accession again.
+            self.eload.ingest(tasks=['accession'], resume=True)
+            assert not os.path.exists(accession_nextflow_dir)
+            assert not os.path.exists(load_nextflow_dir)


### PR DESCRIPTION
* Include `resume` parameter in ingestion, which is passed to Nextflow; any functionality in Python will be re-run
* Refactor `eload_ingestion` to consolidate Nextflow management
* Refactor tests in a futile attempt to improve readability
* Remove merge step from `variant_load`, as it's no longer needed and interferes with Nextflow resumption

(Previous draft version is in a [branch](https://github.com/apriltuesday/eva-submission/tree/ingestion-resume), just in case.)