### PR TITLE
Add check for presence of multiple contig synonyms in the report

### DIFF
--- a/tests/resources/validations/multiple_synonyms_text_assembly_report.txt
+++ b/tests/resources/validations/multiple_synonyms_text_assembly_report.txt
@@ -1,0 +1,2 @@
+Line 3: Multiple synonyms  found for contig '1' in FASTA index file: CM000663.1 NC_000001.10
+Line 4: Multiple synonyms  found for contig 'X' in FASTA index file: CM000685.1 NC_000023.10

--- a/tests/test_eload_validation.py
+++ b/tests/test_eload_validation.py
@@ -51,7 +51,19 @@ class TestEloadValidation(TestCase):
                 "Line 54: Chromosome Chr14, position 11665, reference allele 'A' does not match the reference sequence, expected 'T'",
                 "Line 55: Chromosome Chr14, position 11839, reference allele 'G' does not match the reference sequence, expected 'a'"
             ],
-            14
+            14, [], 0
+        )
+        assert self.validation.parse_assembly_check_report(mismatch_assembly_report) == expected
+
+    def test_parse_assembly_check_report_duplicate_synonym(self):
+        mismatch_assembly_report = os.path.join(self.resources_folder, 'validations', 'multiple_synonyms_text_assembly_report.txt')
+        expected = (
+            [], 0,
+            [
+                "Line 3: Multiple synonyms  found for contig '1' in FASTA index file: CM000663.1 NC_000001.10",
+                "Line 4: Multiple synonyms  found for contig 'X' in FASTA index file: CM000685.1 NC_000023.10"
+            ],
+            2
         )
         assert self.validation.parse_assembly_check_report(mismatch_assembly_report) == expected
 

--- a/tests/test_vep_utils.py
+++ b/tests/test_vep_utils.py
@@ -5,7 +5,6 @@ from unittest import TestCase
 from unittest.mock import Mock, patch
 
 from ebi_eva_common_pyutils.config import cfg
-from ebi_eva_common_pyutils.logger import logging_config
 
 from eva_submission.submission_config import load_config
 from eva_submission.vep_utils import recursive_nlst, get_vep_and_vep_cache_version_from_ensembl, \
@@ -64,11 +63,11 @@ drwxrwxr-x    2 ftp      ftp        102400 Apr 13 13:59 2_collection
 
     def test_get_vep_versions_from_ensembl(self):
         vep_version, cache_version, vep_species = get_vep_and_vep_cache_version_from_ensembl('GCA_000827895.1')
-        self.assertEqual(vep_version, 105)
-        self.assertEqual(cache_version, 52)
+        self.assertEqual(vep_version, 106)
+        self.assertEqual(cache_version, 53)
         self.assertEqual(vep_species, 'thelohanellus_kitauei')
         assert os.path.exists(os.path.join(cfg['vep_cache_path'], 'thelohanellus_kitauei'))
-        assert os.listdir(os.path.join(cfg['vep_cache_path'], 'thelohanellus_kitauei')) == ['52_ASM82789v1']
+        assert os.listdir(os.path.join(cfg['vep_cache_path'], 'thelohanellus_kitauei')) == ['53_ASM82789v1']
 
     def test_get_vep_versions_from_ensembl_not_found(self):
         vep_version, cache_version, vep_species = get_vep_and_vep_cache_version_from_ensembl('GCA_015220235.1')


### PR DESCRIPTION
When multiple synonymous contigs are in the report the assembly checker cannot validate the results. This is now reported accurately by the validation.