### PR TITLE
EVA-2846 - Metadata load for existing project

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -52,6 +52,7 @@ jobs:
     - name: Test nextflow workflows
       run: |
         # Run nextflow tests
+        export NXF_DEFAULT_DSL=1
         tests/nextflow-tests/run_tests.sh
         tests/nextflow-tests/run_tests_human.sh
         tests/nextflow-tests/run_tests_validation.sh

--- a/eva_submission/ENA_submission/xlsx_to_ENA_xml.py
+++ b/eva_submission/ENA_submission/xlsx_to_ENA_xml.py
@@ -96,13 +96,17 @@ class EnaXlsxConverter(AppLogger):
 
     @cached_property
     def is_existing_project(self):
+        return self.existing_project is not None
+
+    @cached_property
+    def existing_project(self):
         prj_alias = self.reader.project.get('Project Alias', '')
         prj_title = self.reader.project.get('Project Title', '')
-        if re.match(r'^PRJ(EB|NA)', prj_alias):
-            return check_existing_project(prj_alias)
-        elif re.match(r'^PRJ(EB|NA)', prj_title):
-            return check_existing_project(prj_title)
-        return False
+        if re.match(r'^PRJ(EB|NA)', prj_alias) and check_existing_project(prj_alias):
+            return prj_alias
+        elif re.match(r'^PRJ(EB|NA)', prj_title) and check_existing_project(prj_title):
+            return prj_title
+        return None
 
     def _create_project_xml(self):
         """

--- a/eva_submission/eload_brokering.py
+++ b/eva_submission/eload_brokering.py
@@ -56,7 +56,7 @@ class EloadBrokering(Eload):
             submission_file, project_file, analysis_file = converter.create_submission_files()
 
             if converter.is_existing_project:
-                # Set the project in the config. bosed on the spreadsheet
+                # Set the project in the config, based on the spreadsheet
                 self.eload_cfg.set('brokering', 'ena', 'PROJECT', value=converter.existing_project)
                 self.eload_cfg.set('brokering', 'ena', 'existing_project', value=True)
 

--- a/eva_submission/eload_brokering.py
+++ b/eva_submission/eload_brokering.py
@@ -49,13 +49,16 @@ class EloadBrokering(Eload):
     def broker_to_ena(self, force=False, existing_project=None):
         if not self.eload_cfg.query('brokering', 'ena', 'PROJECT') or force:
             ena_spreadsheet = os.path.join(self._get_dir('ena'), 'metadata_spreadsheet.xlsx')
-            if existing_project:
-                # Set the project in the config. It will be added to the metadata sheet which is then converted to XML
-                self.eload_cfg.set('brokering', 'ena', 'PROJECT', value=existing_project)
-                self.eload_cfg.set('brokering', 'ena', 'existing_project', value=True)
-            self.update_metadata_from_config(self.eload_cfg['validation']['valid']['metadata_spreadsheet'], ena_spreadsheet)
+            # Set the project in the metadata sheet which is then converted to XML
+            self.update_metadata_from_config(self.eload_cfg['validation']['valid']['metadata_spreadsheet'],
+                                             ena_spreadsheet, existing_project)
             converter = EnaXlsxConverter(ena_spreadsheet, self._get_dir('ena'), self.eload)
             submission_file, project_file, analysis_file = converter.create_submission_files()
+
+            if converter.is_existing_project:
+                # Set the project in the config. bosed on the spreadsheet
+                self.eload_cfg.set('brokering', 'ena', 'PROJECT', value=converter.existing_project)
+                self.eload_cfg.set('brokering', 'ena', 'existing_project', value=True)
 
             # Upload the VCF to ENA FTP
             ena_uploader = ENAUploader(self.eload)

--- a/eva_submission/eload_brokering.py
+++ b/eva_submission/eload_brokering.py
@@ -10,7 +10,7 @@ from eva_submission import NEXTFLOW_DIR
 from eva_submission.ENA_submission.upload_to_ENA import ENAUploader
 from eva_submission.biosamples_submission import SampleMetadataSubmitter
 from eva_submission.eload_submission import Eload
-from eva_submission.eload_utils import read_md5, check_existing_project
+from eva_submission.eload_utils import read_md5
 from eva_submission.ENA_submission.xlsx_to_ENA_xml import EnaXlsxConverter
 from eva_submission.submission_config import EloadConfig
 
@@ -50,7 +50,7 @@ class EloadBrokering(Eload):
         if not self.eload_cfg.query('brokering', 'ena', 'PROJECT') or force:
             ena_spreadsheet = os.path.join(self._get_dir('ena'), 'metadata_spreadsheet.xlsx')
             # Set the project in the metadata sheet which is then converted to XML
-            self.update_metadata_from_config(self.eload_cfg['validation']['valid']['metadata_spreadsheet'],
+            self.update_metadata_spreadsheet(self.eload_cfg['validation']['valid']['metadata_spreadsheet'],
                                              ena_spreadsheet, existing_project)
             converter = EnaXlsxConverter(ena_spreadsheet, self._get_dir('ena'), self.eload)
             submission_file, project_file, analysis_file = converter.create_submission_files()

--- a/eva_submission/eload_ingestion.py
+++ b/eva_submission/eload_ingestion.py
@@ -192,54 +192,23 @@ class EloadIngestion(Eload):
         if self.eload_cfg.query('brokering', 'ena', 'existing_project'):
             analyses = self.eload_cfg.query('brokering', 'ANALYSIS')
             for analysis_accession in analyses.values():
-                self.load_from_ena_from_analysis(analysis_accession)
+                self.load_from_ena_from_project_or_analysis(analysis_accession)
 
         else:
-            self.load_from_ena_from_project()
+            self.load_from_ena_from_project_or_analysis()
 
-    def load_from_ena_from_project(self):
+    def load_from_ena_from_project_or_analysis(self, analysis_accession=None):
         """
-        Loads project metadata from ENA into EVADEV.
+        Loads Analysis metadata from ENA into EVADEV to the project associated with this ELOAD or to an analysis
+        if it is specified.
         """
+        # Current submission process never changes -c or -v
+        command = (f"perl {cfg['executable']['load_from_ena']} -p {self.project_accession} -c, submitted -v 1 "
+                   f"-l {self._get_dir('scratch')} -e {str(self.eload_num)}")
+        if analysis_accession:
+            command += f' -A -a {analysis_accession}'
         try:
-            command_utils.run_command_with_output(
-                'Load metadata from ENA to EVADEV',
-                ' '.join((
-                    'perl', cfg['executable']['load_from_ena'],
-                    '-p', self.project_accession,
-                    # Current submission process never changes -c or -v
-                    '-c', 'submitted',
-                    '-v', '1',
-                    # -l is only checked for when -c=eva_value_added, so in reality never used
-                    '-l', self._get_dir('scratch'),
-                    '-e', str(self.eload_num)
-                ))
-            )
-            self.eload_cfg.set(self.config_section, 'ena_load', value='success')
-        except subprocess.CalledProcessError as e:
-            self.error('ENA metadata load failed: aborting ingestion.')
-            self.eload_cfg.set(self.config_section, 'ena_load', value='failure')
-            raise e
-
-    def load_from_ena_from_analysis(self, analysis_accession):
-        """
-        Loads Analysis metadata from ENA into EVADEV to an existing project.
-        """
-        try:
-            command_utils.run_command_with_output(
-                'Load metadata from ENA to EVADEV',
-                ' '.join((
-                    'perl', cfg['executable']['load_from_ena'],
-                    '-p', self.project_accession,
-                    '-A', '-a', analysis_accession,
-                    # Current submission process never changes -c or -v
-                    '-c', 'submitted',
-                    '-v', '1',
-                    # -l is only checked for when -c=eva_value_added, so in reality never used
-                    '-l', self._get_dir('scratch'),
-                    '-e', str(self.eload_num)
-                ))
-            )
+            command_utils.run_command_with_output('Load metadata from ENA to EVADEV', command)
             self.eload_cfg.set(self.config_section, 'ena_load', value='success')
         except subprocess.CalledProcessError as e:
             self.error('ENA metadata load failed: aborting ingestion.')

--- a/eva_submission/eload_ingestion.py
+++ b/eva_submission/eload_ingestion.py
@@ -203,7 +203,7 @@ class EloadIngestion(Eload):
         if it is specified.
         """
         # Current submission process never changes -c or -v
-        command = (f"perl {cfg['executable']['load_from_ena']} -p {self.project_accession} -c, submitted -v 1 "
+        command = (f"perl {cfg['executable']['load_from_ena']} -p {self.project_accession} -c submitted -v 1 "
                    f"-l {self._get_dir('scratch')} -e {str(self.eload_num)}")
         if analysis_accession:
             command += f' -A -a {analysis_accession}'

--- a/eva_submission/eload_ingestion.py
+++ b/eva_submission/eload_ingestion.py
@@ -189,6 +189,15 @@ class EloadIngestion(Eload):
             provision_new_database_for_variant_warehouse(db_info['db_name'])
 
     def load_from_ena(self):
+        if self.eload_cfg.query('brokering', 'ena', 'existing_project'):
+            analyses = self.eload_cfg.query('brokering', 'ANALYSIS')
+            for analysis_accession in analyses.values():
+                self.load_from_ena_from_analysis(analysis_accession)
+
+        else:
+            self.load_from_ena_from_project()
+
+    def load_from_ena_from_project(self):
         """
         Loads project metadata from ENA into EVADEV.
         """
@@ -198,6 +207,31 @@ class EloadIngestion(Eload):
                 ' '.join((
                     'perl', cfg['executable']['load_from_ena'],
                     '-p', self.project_accession,
+                    # Current submission process never changes -c or -v
+                    '-c', 'submitted',
+                    '-v', '1',
+                    # -l is only checked for when -c=eva_value_added, so in reality never used
+                    '-l', self._get_dir('scratch'),
+                    '-e', str(self.eload_num)
+                ))
+            )
+            self.eload_cfg.set(self.config_section, 'ena_load', value='success')
+        except subprocess.CalledProcessError as e:
+            self.error('ENA metadata load failed: aborting ingestion.')
+            self.eload_cfg.set(self.config_section, 'ena_load', value='failure')
+            raise e
+
+    def load_from_ena_from_analysis(self, analysis_accession):
+        """
+        Loads Analysis metadata from ENA into EVADEV to an existing project.
+        """
+        try:
+            command_utils.run_command_with_output(
+                'Load metadata from ENA to EVADEV',
+                ' '.join((
+                    'perl', cfg['executable']['load_from_ena'],
+                    '-p', self.project_accession,
+                    '-A', analysis_accession,
                     # Current submission process never changes -c or -v
                     '-c', 'submitted',
                     '-v', '1',

--- a/eva_submission/eload_ingestion.py
+++ b/eva_submission/eload_ingestion.py
@@ -231,7 +231,7 @@ class EloadIngestion(Eload):
                 ' '.join((
                     'perl', cfg['executable']['load_from_ena'],
                     '-p', self.project_accession,
-                    '-A', analysis_accession,
+                    '-A', '-a', analysis_accession,
                     # Current submission process never changes -c or -v
                     '-c', 'submitted',
                     '-v', '1',

--- a/eva_submission/eload_submission.py
+++ b/eva_submission/eload_submission.py
@@ -89,7 +89,7 @@ class Eload(AppLogger):
         hold_date = get_hold_date_from_ena(project_accession, project_alias)
         self.eload_cfg.set('brokering', 'ena', 'hold_date', value=hold_date)
 
-    def update_metadata_from_config(self, input_spreadsheet, output_spreadsheet=None):
+    def update_metadata_from_config(self, input_spreadsheet, output_spreadsheet=None, existing_project=None):
         reader = EvaXlsxReader(input_spreadsheet)
         single_analysis_alias = None
         if len(reader.analysis) == 1:
@@ -133,8 +133,8 @@ class Eload(AppLogger):
                 })
 
         project_row = reader.project
-        if self.eload_cfg.query('brokering', 'ena', 'existing_project'):
-            project_row['Project Alias'] = self.eload_cfg.query('brokering', 'ena', 'PROJECT')
+        if existing_project:
+            project_row['Project Alias'] = existing_project
 
         if output_spreadsheet:
             eva_xls_writer = EvaXlsxWriter(input_spreadsheet, output_spreadsheet)

--- a/eva_submission/eload_submission.py
+++ b/eva_submission/eload_submission.py
@@ -89,7 +89,7 @@ class Eload(AppLogger):
         hold_date = get_hold_date_from_ena(project_accession, project_alias)
         self.eload_cfg.set('brokering', 'ena', 'hold_date', value=hold_date)
 
-    def update_metadata_from_config(self, input_spreadsheet, output_spreadsheet=None, existing_project=None):
+    def update_metadata_spreadsheet(self, input_spreadsheet, output_spreadsheet=None, existing_project=None):
         reader = EvaXlsxReader(input_spreadsheet)
         single_analysis_alias = None
         if len(reader.analysis) == 1:

--- a/tests/test_eload_brokering.py
+++ b/tests/test_eload_brokering.py
@@ -195,7 +195,7 @@ ANALYSIS: ERZ0000001
             }
         }
         self.eload.eload_cfg.set('brokering', 'analyses', value=analyses)
-        self.eload.update_metadata_from_config(metadata_file, ena_metadata_file)
+        self.eload.update_metadata_spreadsheet(metadata_file, ena_metadata_file)
 
         # Check that the Files get set to the merged file name and that the analysis alias is modified
         reader = EvaXlsxReader(ena_metadata_file)

--- a/tests/test_eload_ingestion.py
+++ b/tests/test_eload_ingestion.py
@@ -166,9 +166,9 @@ class TestEloadIngestion(TestCase):
         with self._patch_metadata_handle(), \
                 patch('eva_submission.eload_ingestion.command_utils.run_command_with_output', autospec=True) as mockrun:
             analysis_accession = 'ERZ2499196'
-            self.eload.load_from_ena_from_analysis(analysis_accession)
-            command = ('perl /path/to/load_from_ena_script -p PRJEB12345 -A ERZ2499196 -c submitted -v 1 -l '
-                       f'{self.eload._get_dir("scratch")} -e 33')
+            self.eload.load_from_ena_from_project_or_analysis(analysis_accession)
+            command = ('perl /path/to/load_from_ena_script -p PRJEB12345 -c submitted -v 1 -l '
+                       f'{self.eload._get_dir("scratch")} -e 33 -A -a ERZ2499196')
             mockrun.assert_called_once_with('Load metadata from ENA to EVADEV', command)
 
     def test_ingest_accession(self):

--- a/tests/test_eload_ingestion.py
+++ b/tests/test_eload_ingestion.py
@@ -162,6 +162,15 @@ class TestEloadIngestion(TestCase):
             m_post.return_value.text = self.get_mock_result_for_ena_date()
             self.eload.ingest(tasks=['metadata_load'])
 
+    def test_load_from_ena_from_analysis(self):
+        with self._patch_metadata_handle(), \
+                patch('eva_submission.eload_ingestion.command_utils.run_command_with_output', autospec=True) as mockrun:
+            analysis_accession = 'ERZ2499196'
+            self.eload.load_from_ena_from_analysis(analysis_accession)
+            command = ('perl /path/to/load_from_ena_script -p PRJEB12345 -A ERZ2499196 -c submitted -v 1 -l '
+                       f'{self.eload._get_dir("scratch")} -e 33')
+            mockrun.assert_called_once_with('Load metadata from ENA to EVADEV', command)
+
     def test_ingest_accession(self):
         with self._patch_metadata_handle(), \
                 patch('eva_submission.eload_ingestion.get_all_results_for_query') as m_get_results, \


### PR DESCRIPTION
Add support for metadata load of the analysis present in the config based on the existing_project in the config

In brokering switch around the propagation of existing project from command line to spreadsheet to config so that the existing project could be set by the spreadsheet directly and still be reported.