### PR TITLE
EVA-2693 Update BioSamples

### DIFF
--- a/eva_submission/biosamples_submission.py
+++ b/eva_submission/biosamples_submission.py
@@ -199,8 +199,6 @@ class BSDSubmitter(AppLogger):
                     'type': attribute,
                     'value': current_sample['characteristics'].get(attribute)[0].get('text')
                 })
-            # else:
-            #     attributes_pre.append({})
             attributes_post.append({
                 'type': attribute,
                 'value': future_sample['characteristics'].get(attribute)[0].get('text')

--- a/eva_submission/biosamples_submission.py
+++ b/eva_submission/biosamples_submission.py
@@ -139,6 +139,13 @@ class HALCommunicator(AppLogger):
         return self._req('GET', self.bsd_url).json()
 
 
+class AAPHALCommunicator(HALCommunicator):
+
+    def __init__(self, auth_url, bsd_url, username, password, domain=None):
+        super(AAPHALCommunicator, self).__init__(auth_url, bsd_url, username, password)
+        self.domain = domain
+
+
 class WebinHALCommunicator(HALCommunicator):
 
     @cached_property
@@ -150,18 +157,21 @@ class WebinHALCommunicator(HALCommunicator):
         self._validate_response(response)
         return response.text
 
+    @property
+    def webin_submission_account_id(self):
+        return self.username
+
 
 class BSDSubmitter(AppLogger):
 
-    def __init__(self, communicator, domain):
+    def __init__(self, communicator):
         self.communicator = communicator
-        self.domain = domain
         self.sample_name_to_accession = {}
 
     def should_create(self, sample):
         return 'accession' not in sample
 
-    def should_overwrite(self, sample):
+    def should_update(self, sample):
         return 'accession' in sample and 'name' in sample
 
     def should_retrieve(self, sample):
@@ -171,26 +181,63 @@ class BSDSubmitter(AppLogger):
         for sample in samples_data:
             # If we're only retrieving, don't need to validate.
             if not self.should_retrieve(sample):
-                sample['domain'] = self.domain
+                if hasattr(self.communicator, "domain"):
+                    sample['domain'] = self.communicator.domain
+                if hasattr(self.communicator, "webin_submission_account_id"):
+                    sample['webinSubmissionAccountId'] = self.communicator.webin_submission_account_id
                 self.communicator.follows_link('samples', join_url='validate', method='POST', json=sample)
+
+    def convert_sample_data_to_curation_object(self, future_sample):
+        """Curation object can only change 3 attributes characteristics, externalReferences and relationships"""
+        current_sample = self.communicator.follows_link('samples', method='GET', join_url=future_sample.get('accession'))
+        curation_object = {}
+        attributes_pre = []
+        attributes_post = []
+        for attribute in future_sample['characteristics']:
+            if attribute in current_sample['characteristics']:
+                attributes_pre.append({
+                    'type': attribute,
+                    'value': current_sample['characteristics'].get(attribute)[0].get('text')
+                })
+            # else:
+            #     attributes_pre.append({})
+            attributes_post.append({
+                'type': attribute,
+                'value': future_sample['characteristics'].get(attribute)[0].get('text')
+            })
+        curation_object['attributesPre'] = attributes_pre
+        curation_object['attributesPost'] = attributes_post
+
+        # for externalReferences and relationships we're assuming you want to replace them all
+        curation_object['externalReferencesPre'] = current_sample.get('externalReferences', [])
+        curation_object['externalReferencesPost'] = future_sample.get('externalReferences', [])
+        curation_object['relationshipsPre'] = current_sample.get('relationships', [])
+        curation_object['relationshipsPost'] = future_sample.get('relationships', [])
+
+        return dict(curation=curation_object, sample=future_sample.get('accession'))
 
     def submit_to_bsd(self, samples_data):
         """
         This function creates or updates samples in BioSamples and return a map of sample name to sample accession
         """
         for sample in samples_data:
-            sample['domain'] = self.domain
+            if hasattr(self.communicator, "domain"):
+                sample['domain'] = self.communicator.domain
+            if hasattr(self.communicator, "webin_submission_account_id"):
+                sample['webinSubmissionAccountId'] = self.communicator.webin_submission_account_id
             if self.should_create(sample):
                 # Create a sample
                 sample_json = self.communicator.follows_link('samples', method='POST', json=sample)
                 self.debug('Accession sample ' + sample.get('name') + ' as ' + sample_json.get('accession'))
             # To trigger and update we require at least the sample name to be populated
-            # Then push the sample as it is documented
-            # NOTE that it will replace the sample so potentially remove fields that were present before.
-            elif self.should_overwrite(sample):
+            # NOTE that it create a curation object that will only update fields that are present in the
+            # characteristics, externalReference and relationship.
+            elif self.should_update(sample):
                 self.debug('Update sample ' + sample.get('name') + ' with accession ' + sample.get('accession'))
-                sample_json = self.communicator.follows_link('samples', method='PUT', join_url=sample.get('accession'),
-                                                             json=sample)
+                curation_object = self.convert_sample_data_to_curation_object(sample)
+                sample_json = self.communicator.follows_link('samples', method='POST',
+                                                             join_url=sample.get('accession')+'/curationlinks',
+                                                             json=curation_object)
 
             # Otherwise Keep the sample as is and retrieve the name so that list of sample to accession is complete
             else:
@@ -205,9 +252,10 @@ class SampleSubmitter(AppLogger):
     project_mapping = {}
 
     def __init__(self):
-        communicator = HALCommunicator(cfg.query('biosamples', 'aap_url'), cfg.query('biosamples', 'bsd_url'),
-                                       cfg.query('biosamples', 'username'), cfg.query('biosamples', 'password'))
-        # If the config has the credential for using webin with BioSamples
+        communicator = AAPHALCommunicator(cfg.query('biosamples', 'aap_url'), cfg.query('biosamples', 'bsd_url'),
+                                          cfg.query('biosamples', 'username'), cfg.query('biosamples', 'password'),
+                                          cfg.query('biosamples', 'domain'))
+        # If the config has the credential for using webin with BioSamples prefer webin
         if cfg.query('biosamples', 'webin_url') and cfg.query('biosamples', 'webin_username') and \
                 cfg.query('biosamples', 'webin_password'):
             communicator = WebinHALCommunicator(cfg.query('biosamples', 'webin_url'),
@@ -215,7 +263,7 @@ class SampleSubmitter(AppLogger):
                                                 cfg.query('biosamples', 'webin_username'),
                                                 cfg.query('biosamples', 'webin_password'))
 
-        self.submitter = BSDSubmitter(communicator, cfg.query('biosamples', 'domain'))
+        self.submitter = BSDSubmitter(communicator)
         self.sample_data = None
 
     @staticmethod
@@ -383,6 +431,7 @@ class SampleMetadataSubmitter(SampleSubmitter):
 
     def all_sample_names(self):
         return [s.get('name') for s in self.sample_data]
+
 
 class SampleReferenceSubmitter(SampleSubmitter):
 

--- a/eva_submission/eload_brokering.py
+++ b/eva_submission/eload_brokering.py
@@ -8,7 +8,7 @@ from ebi_eva_common_pyutils.config import cfg
 
 from eva_submission import NEXTFLOW_DIR
 from eva_submission.ENA_submission.upload_to_ENA import ENAUploader, ENAUploaderAsync
-from eva_submission.biosamples_submission import SampleMetadataSubmitter
+from eva_submission.biosamples_submission import SampleMetadataSubmitter, SampleReferenceSubmitter
 from eva_submission.eload_submission import Eload
 from eva_submission.eload_utils import read_md5
 from eva_submission.submission_config import EloadConfig
@@ -36,6 +36,7 @@ class EloadBrokering(Eload):
         self.prepare_brokering(force=('preparation' in brokering_tasks_to_force))
         self.upload_to_bioSamples(force=('biosamples' in brokering_tasks_to_force))
         self.broker_to_ena(force=('ena' in brokering_tasks_to_force), existing_project=existing_project, async_upload=async_upload)
+        self.update_bioSamples(force=('update_biosamples' in brokering_tasks_to_force))
 
     def prepare_brokering(self, force=False):
         valid_analyses = self.eload_cfg.query('validation', 'valid', 'analyses', ret_default=[])
@@ -87,8 +88,8 @@ class EloadBrokering(Eload):
 
     def upload_to_bioSamples(self, force=False):
         metadata_spreadsheet = self.eload_cfg['validation']['valid']['metadata_spreadsheet']
-        sample_tab_submitter = SampleMetadataSubmitter(metadata_spreadsheet)
-        if sample_tab_submitter.check_submit_done() and not force:
+        sample_metadata_submitter = SampleMetadataSubmitter(metadata_spreadsheet)
+        if sample_metadata_submitter.check_submit_done() and not force:
             self.info('Biosamples accession already provided in the metadata, Skip!')
             self.eload_cfg.set('brokering', 'Biosamples', 'pass', value=True)
         elif (
@@ -98,11 +99,11 @@ class EloadBrokering(Eload):
         ):
             self.info('BioSamples brokering is already done, Skip!')
         else:
-            sample_name_to_accession = sample_tab_submitter.submit_to_bioSamples()
+            sample_name_to_accession = sample_metadata_submitter.submit_to_bioSamples()
             # Check whether all samples have been accessioned
             passed = (
                 bool(sample_name_to_accession)
-                and all(sample_name in sample_name_to_accession for sample_name in sample_tab_submitter.all_sample_names())
+                and all(sample_name in sample_name_to_accession for sample_name in sample_metadata_submitter.all_sample_names())
             )
             self.eload_cfg.set('brokering', 'Biosamples', 'date', value=self.now)
             self.eload_cfg.set('brokering', 'Biosamples', 'Samples', value=sample_name_to_accession)
@@ -110,6 +111,10 @@ class EloadBrokering(Eload):
             # Make sure we crash if we haven't brokered everything
             if not passed:
                 raise ValueError('Brokering to BioSamples failed!')
+
+    def updated_bioSamples(self):
+        sample_reference_submitter = SampleReferenceSubmitter(self.eload_cfg.query('brokering', 'ena', 'PROJECT'))
+        sample_reference_submitter.submit_to_bioSamples()
 
     def _get_valid_vcf_files(self):
         valid_vcf_files = []

--- a/eva_submission/eload_brokering.py
+++ b/eva_submission/eload_brokering.py
@@ -62,7 +62,7 @@ class EloadBrokering(Eload):
 
             if ena_uploader.converter.is_existing_project:
                 # Set the project in the config, based on the spreadsheet
-                self.eload_cfg.set('brokering', 'ena', 'PROJECT', value=ena_uploader.converter.is_existing_project)
+                self.eload_cfg.set('brokering', 'ena', 'PROJECT', value=ena_uploader.converter.existing_project)
                 self.eload_cfg.set('brokering', 'ena', 'existing_project', value=True)
 
             # Upload the VCF to ENA FTP

--- a/eva_submission/eload_ingestion.py
+++ b/eva_submission/eload_ingestion.py
@@ -190,7 +190,7 @@ class EloadIngestion(Eload):
 
     def load_from_ena(self):
         if self.eload_cfg.query('brokering', 'ena', 'existing_project'):
-            analyses = self.eload_cfg.query('brokering', 'ANALYSIS')
+            analyses = self.eload_cfg.query('brokering', 'ena', 'ANALYSIS')
             for analysis_accession in analyses.values():
                 self.load_from_ena_from_project_or_analysis(analysis_accession)
 

--- a/tests/test_submit_to_bsd.py
+++ b/tests/test_submit_to_bsd.py
@@ -1,5 +1,6 @@
 import copy
 import os
+import time
 from copy import deepcopy
 from unittest import TestCase
 from unittest.mock import patch, Mock, PropertyMock
@@ -8,7 +9,7 @@ import yaml
 
 from eva_submission import biosamples_submission, ROOT_DIR
 from eva_submission.biosamples_submission import HALCommunicator, BSDSubmitter, SampleMetadataSubmitter, \
-    SampleReferenceSubmitter
+    SampleReferenceSubmitter, AAPHALCommunicator, WebinHALCommunicator
 
 
 class BSDTestCase(TestCase):
@@ -125,6 +126,22 @@ class TestHALCommunicator(BSDTestCase):
             mocked_req.assert_any_call('GET', 'url')
 
 
+class TestWebinHALCommunicator(BSDTestCase):
+    def setUp(self) -> None:
+        self.comm = WebinHALCommunicator('http://webin.example.org', 'http://BSD.example.org', 'user', 'pass')
+
+    def test_webin_submission_account_id(self):
+        assert hasattr(self.comm, 'webin_submission_account_id')
+        assert self.comm.webin_submission_account_id == 'user'
+
+    def test_token(self):
+        with patch('requests.post', return_value=Mock(text='token', status_code=200)) as mocked_post:
+            self.assertEqual(self.comm.token, 'token')
+            print(mocked_post.mock_calls)
+            mocked_post.assert_called_once_with('http://webin.example.org',
+                                                json={'authRealms': ['ENA'], 'password': 'pass', 'username': 'user'})
+
+
 sample_data = [{
         'characteristics': {
             'description': [{'text': 'yellow croaker sample 12'}],
@@ -170,9 +187,10 @@ class TestBSDSubmitter(BSDTestCase):
             with open(file_name) as open_file:
                 self.config = yaml.safe_load(open_file)
         self.sample_data = deepcopy(sample_data)
-        communicator = HALCommunicator(self.config.get('aap_url'), self.config.get('bsd_url'),
-                                       self.config.get('username'), self.config.get('password'))
-        self.submitter = BSDSubmitter(communicator, self.config.get('domain'))
+        communicator = AAPHALCommunicator(self.config.get('aap_url'), self.config.get('bsd_url'),
+                                       self.config.get('username'), self.config.get('password'),
+                                       self.config.get('domain'))
+        self.submitter = BSDSubmitter(communicator)
 
     def test_validate_in_bsd(self):
         self.submitter.validate_in_bsd(self.sample_data)
@@ -180,6 +198,28 @@ class TestBSDSubmitter(BSDTestCase):
     def test_validate_partial_data(self):
         # Sample data without name should still validate
         self.submitter.validate_in_bsd([{'accession': 'SAME1234'}])
+
+    def test_convert_sample_data_to_curation_object(self):
+        sample_data = {
+            'characteristics': {'organism': [{'text': 'Larimichthys polyactis'}]},
+            'name': 'LH1',
+            'release': '2020-07-06T19:09:29.090Z'
+        }
+
+        self.submitter.submit_to_bsd([sample_data])
+        expected_curation = {
+            'curation': {'attributesPost': [{'type': 'description', 'value': 'yellow croaker sample 12'}],
+                         'attributesPre': [],
+                         'externalReferencesPost': [],
+                         'externalReferencesPre': [],
+                         'relationshipsPost': [],
+                         'relationshipsPre': []},
+            'sample': self.submitter.sample_name_to_accession.get('LH1')
+        }
+        sample_data_update = {'characteristics': {'description': [{'text': 'yellow croaker sample 12'}]},
+                              'accession': self.submitter.sample_name_to_accession.get('LH1')}
+        curation_object = self.submitter.convert_sample_data_to_curation_object(sample_data_update)
+        self.assertEqual(curation_object, expected_curation)
 
     def test_submit_to_bsd_create(self):
         self.submitter.submit_to_bsd(self.sample_data)
@@ -200,20 +240,24 @@ class TestBSDSubmitter(BSDTestCase):
         self.assertEqual(sample_json['characteristics']['collected_by'][0]['text'], 'first1 last1')
 
         # Modify the descriptions and remove the collected_by
-        updated_data = copy.deepcopy(self.sample_data)
         modified_text = 'blue croaker sample 12'
-        updated_data[0]['characteristics']['description'] = [{'text': modified_text}]
-        updated_data[0]['characteristics'].pop('collected_by')
-        updated_data[0]['characteristics']['new metadata'] = [{'text': 'New value'}]
-        updated_data[0]['accession'] = accession
-        self.submitter.submit_to_bsd(updated_data)
+        updated_sample = {
+            'accession': accession,
+            'name': 'LH1',
+            'characteristics': {
+                'description': [{'text': modified_text}],
+                'new metadata': [{'text': 'New value'}]
+            },
+            'externalReferences': [{'url': 'https://www.ebi.ac.uk/eva/?eva-study=PRJEB001'}]
+        }
+        self.submitter.submit_to_bsd([updated_sample])
         accession = self.submitter.sample_name_to_accession.get('LH1')
         # Needs to avoid requests' cache otherwise we get the previous version
         updated_sample_json = self.submitter.communicator.follows_link('samples', join_url=accession,
                                                                        headers={'Cache-Control': 'no-cache'})
         self.assertEqual(updated_sample_json['characteristics']['new metadata'][0]['text'], 'New value')
         self.assertEqual(updated_sample_json['characteristics']['description'][0]['text'], 'blue croaker sample 12')
-        self.assertNotIn('collected_by', updated_sample_json['characteristics'])
+        self.assertEqual(updated_sample_json['externalReferences'][0]['url'], 'https://www.ebi.ac.uk/eva/?eva-study=PRJEB001')
 
     def test_submit_to_bsd_no_change(self):
         self.submitter.submit_to_bsd(self.sample_data)

--- a/tests/test_submit_to_bsd.py
+++ b/tests/test_submit_to_bsd.py
@@ -1,6 +1,4 @@
-import copy
 import os
-import time
 from copy import deepcopy
 from unittest import TestCase
 from unittest.mock import patch, Mock, PropertyMock
@@ -130,9 +128,8 @@ class TestWebinHALCommunicator(BSDTestCase):
     def setUp(self) -> None:
         self.comm = WebinHALCommunicator('http://webin.example.org', 'http://BSD.example.org', 'user', 'pass')
 
-    def test_webin_submission_account_id(self):
-        assert hasattr(self.comm, 'webin_submission_account_id')
-        assert self.comm.webin_submission_account_id == 'user'
+    def test_communicator_attributes(self):
+        assert self.comm.communicator_attributes == {'webinSubmissionAccountId': 'user'}
 
     def test_token(self):
         with patch('requests.post', return_value=Mock(text='token', status_code=200)) as mocked_post:


### PR DESCRIPTION
This PR brings a new class that can update All provided BioSamples accession with an external reference to the EVA study page.
Also add the ability to authenticate to BioSamples via ENA webin credentials
All updates are done via curation objects rather than edits to the original object