### PR TITLE
When submitting to existing project create alias based on ELOAD

### DIFF
--- a/eva_submission/ENA_submission/upload_to_ENA.py
+++ b/eva_submission/ENA_submission/upload_to_ENA.py
@@ -73,7 +73,7 @@ class ENAUploader(AppLogger):
 
     def upload_xml_files_to_ena(self, dry_ena_upload=False):
         """Upload the xml files to the webin submission endpoint and parse the receipt."""
-        submission_file, project_file, analysis_file = self.converter.create_submission_files()
+        submission_file, project_file, analysis_file = self.converter.create_submission_files(self.eload)
         file_dict = {
             'SUBMISSION': (os.path.basename(submission_file), get_file_content(submission_file), 'application/xml'),
             'ANALYSIS': (os.path.basename(analysis_file), get_file_content(analysis_file), 'application/xml')
@@ -117,7 +117,7 @@ class ENAUploaderAsync(ENAUploader):
     def upload_xml_files_to_ena(self, dry_ena_upload=False):
         """Upload the xml file to the asynchronous endpoint and monitor the results from the poll endpoint."""
 
-        webin_file = self.converter.create_single_submission_file()
+        webin_file = self.converter.create_single_submission_file(self.eload)
         file_dict = {
             'file': (os.path.basename(webin_file), get_file_content(webin_file), 'application/xml'),
         }

--- a/eva_submission/ENA_submission/xlsx_to_ENA_xml.py
+++ b/eva_submission/ENA_submission/xlsx_to_ENA_xml.py
@@ -290,10 +290,10 @@ class EnaXlsxConverter(AppLogger):
             add_element(analysis_attrib_elemt, 'TAG', element_text='Pipeline_Description')
             add_element(analysis_attrib_elemt, 'VALUE', element_text=analysis_row.get('Pipeline Description').strip())
 
-    def _create_submission_xml(self, files_to_submit, action, project_row):
+    def _create_submission_xml(self, files_to_submit, action, project_row, eload):
         root = Element('SUBMISSION_SET')
         submission_elemt = add_element(root, 'SUBMISSION',
-                                       alias=project_row.get('Project Alias').strip(),
+                                       alias=eload,
                                        center_name=project_row.get('Center'))
         actions_elemt = add_element(submission_elemt, 'ACTIONS')
         for file_dict in files_to_submit:
@@ -313,10 +313,10 @@ class EnaXlsxConverter(AppLogger):
         add_element(action_elemt, 'HOLD', HoldUntilDate=hold_date.strftime('%Y-%m-%d'))
         return root
 
-    def _create_submission_single_xml(self,  action, project_row):
+    def _create_submission_single_xml(self,  action, project_row, eload):
         root = Element('SUBMISSION_SET')
         submission_elemt = add_element(root, 'SUBMISSION',
-                                       alias=project_row.get('Project Alias').strip(),
+                                       alias=eload,
                                        center_name=project_row.get('Center'))
         actions_elemt = add_element(submission_elemt, 'ACTIONS')
         action_elemt = add_element(actions_elemt, 'ACTION')
@@ -339,7 +339,7 @@ class EnaXlsxConverter(AppLogger):
         with open(output_file, 'bw') as open_file:
             open_file.write(prettify(etree))
 
-    def create_submission_files(self):
+    def create_submission_files(self, eload):
         files_to_submit = []
         if not self.is_existing_project:
             files_to_submit.append(
@@ -358,16 +358,16 @@ class EnaXlsxConverter(AppLogger):
         )
 
         action = 'ADD'
-        submission_elemt = self._create_submission_xml(files_to_submit, action, self.reader.project)
+        submission_elemt = self._create_submission_xml(files_to_submit, action, self.reader.project, eload)
         self.write_xml_to_file(submission_elemt, self.submission_file)
 
         return self.submission_file, project_file, self.analysis_file
 
-    def create_single_submission_file(self):
+    def create_single_submission_file(self, eload):
         root = Element('WEBIN')
         # Submission ELEMENT
         action = 'ADD'
-        submissions_elemt = self._create_submission_single_xml(action, self.reader.project)
+        submissions_elemt = self._create_submission_single_xml(action, self.reader.project, eload)
         root.append(submissions_elemt)
 
         # Project ELEMENT

--- a/eva_submission/eload_brokering.py
+++ b/eva_submission/eload_brokering.py
@@ -119,7 +119,9 @@ class EloadBrokering(Eload):
             self.eload_cfg.set('brokering', 'Biosamples', 'pass', value=passed)
             # Make sure we crash if we haven't brokered everything
             if not passed:
-                raise ValueError(f'Not all samples were successfully brokered to BioSamples! Found {len(sample_name_to_accession)} and expectec {len(sample_metadata_submitter.all_sample_names())}')
+                raise ValueError(f'Not all samples were successfully brokered to BioSamples! '
+                                 f'Found {len(sample_name_to_accession)} and expected '
+                                 f'{len(sample_metadata_submitter.all_sample_names())}')
 
     def update_biosamples_with_study(self, force=False):
         if not self.eload_cfg.query('brokering', 'Biosamples', 'backlinks') or force:

--- a/eva_submission/eload_brokering.py
+++ b/eva_submission/eload_brokering.py
@@ -119,7 +119,7 @@ class EloadBrokering(Eload):
             self.eload_cfg.set('brokering', 'Biosamples', 'pass', value=passed)
             # Make sure we crash if we haven't brokered everything
             if not passed:
-                raise ValueError('Brokering to BioSamples failed!')
+                raise ValueError(f'Not all samples were successfully brokered to BioSamples! Found {len(sample_name_to_accession)} and expectec {len(sample_metadata_submitter.all_sample_names())}')
 
     def update_biosamples_with_study(self, force=False):
         if not self.eload_cfg.query('brokering', 'Biosamples', 'backlinks') or force:

--- a/tests/test_xlsx_to_xml.py
+++ b/tests/test_xlsx_to_xml.py
@@ -181,7 +181,7 @@ class TestEnaXlsConverter(TestCase):
     def test_process_metadata_spreadsheet(self):
         with patch('eva_submission.ENA_submission.xlsx_to_ENA_xml.get_scientific_name_from_ensembl') as m_sci_name:
             m_sci_name.return_value = 'Oncorhynchus mykiss'
-            self.converter.create_submission_files()
+            self.converter.create_submission_files('TEST1')
         assert os.path.isfile(os.path.join(self.brokering_folder, 'TEST1.Submission.xml'))
         assert os.path.isfile(os.path.join(self.brokering_folder, 'TEST1.Project.xml'))
         assert os.path.isfile(os.path.join(self.brokering_folder, 'TEST1.Analysis.xml'))
@@ -189,7 +189,7 @@ class TestEnaXlsConverter(TestCase):
     def test_create_submission(self):
         expected_submission = '''
 <SUBMISSION_SET>
-  <SUBMISSION alias="TechFish" center_name="Laboratory of Aquatic Pathobiology">
+  <SUBMISSION alias="ELOAD_1" center_name="Laboratory of Aquatic Pathobiology">
     <ACTIONS>
       <ACTION>
         <ADD source="project.xml" schema="project"/>
@@ -210,7 +210,7 @@ class TestEnaXlsConverter(TestCase):
         ]
         with patch('eva_submission.ENA_submission.xlsx_to_ENA_xml.today',
                    return_value=datetime(year=2021, month=1, day=1)):
-            root = self.converter._create_submission_xml(files_to_submit, 'ADD', self.project_row)
+            root = self.converter._create_submission_xml(files_to_submit, 'ADD', self.project_row, 'ELOAD_1')
             expected_root = ET.fromstring(expected_submission)
         assert elements_equal(root, expected_root)
 
@@ -218,7 +218,7 @@ class TestEnaXlsConverter(TestCase):
         self.project_row['Hold Date'] = datetime(year=2023, month=6, day=25)
         expected_submission = '''
 <SUBMISSION_SET>
-  <SUBMISSION alias="TechFish" center_name="Laboratory of Aquatic Pathobiology">
+  <SUBMISSION alias="ELOAD_1" center_name="Laboratory of Aquatic Pathobiology">
     <ACTIONS>
       <ACTION>
         <ADD source="project.xml" schema="project"/>
@@ -238,12 +238,12 @@ class TestEnaXlsConverter(TestCase):
             {'file_name': 'path/to/project.xml', 'schema': 'project'},
             {'file_name': 'path/to/analysis.xml', 'schema': 'analysis'}
         ]
-        root = self.converter._create_submission_xml(files_to_submit, 'ADD', self.project_row)
+        root = self.converter._create_submission_xml(files_to_submit, 'ADD', self.project_row, 'ELOAD_1')
         expected_root = ET.fromstring(expected_submission)
         assert elements_equal(root, expected_root)
 
     def test_create_submission_files(self):
-        submission_file, project_file, analysis_file = self.converter.create_submission_files()
+        submission_file, project_file, analysis_file = self.converter.create_submission_files('ELOAD_1')
         assert os.path.exists(submission_file)
         assert os.path.exists(project_file)
         assert os.path.exists(analysis_file)
@@ -251,13 +251,13 @@ class TestEnaXlsConverter(TestCase):
     def test_create_submission_files_for_existing_project(self):
         # When the project already exist not PROJECT XML will be generated
         with patch.object(EnaXlsxConverter, 'is_existing_project', return_value=True):
-            submission_file, project_file, analysis_file = self.converter.create_submission_files()
+            submission_file, project_file, analysis_file = self.converter.create_submission_files('ELOAD_1')
             assert os.path.exists(submission_file)
             assert project_file is None
             assert os.path.exists(analysis_file)
             assert not os.path.exists(self.converter.project_file)
 
     def test_create_single_submission_files(self):
-        self.converter.create_single_submission_file()
+        self.converter.create_single_submission_file('ELOAD_1')
 
 


### PR DESCRIPTION
When submitting multiple analysis to the same project through several submissions the scond would work because it would use the Project as alias then the third would not because it would also use the existing project as alias. This replace the Alias with the ELOAD number.
