### PR TITLE
EVA-2904 - Add remapping and clustering to ingestion automation

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -57,3 +57,4 @@ jobs:
         tests/nextflow-tests/run_tests_prep_brokering.sh
         tests/nextflow-tests/run_tests.sh
         tests/nextflow-tests/run_tests_human.sh
+        tests/nextflow-tests/run_tests_clustering.sh

--- a/README.md
+++ b/README.md
@@ -85,11 +85,12 @@ python broker_submission.py --eload 677 --project_accession PRJEB00001
 ### Data ingestion
 
 After validation and brokering are done, the data can be loaded into our databases and made publicly available.
-This involves three main steps:
+This involves four main steps:
 
 1. Loading submission metadata from ENA into EVAPRO (`metadata_load`)
-2. Accessioning VCF files (`accession`)
+2. Accessioning VCF files and making files public (`accession`)
 3. Loading into the variant warehouse (`variant_load`)
+4. Clustering in the current supported assembly, including remapping if necessary (`cluster`)
 
 By default, the script will run all of these tasks, though you may specify a subset using the flag `--tasks`.
 Note that as some steps are long-running the script is best run in a screen/tmux session.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ This involves four main steps:
 1. Loading submission metadata from ENA into EVAPRO (`metadata_load`)
 2. Accessioning VCF files and making files public (`accession`)
 3. Loading into the variant warehouse (`variant_load`)
-4. Clustering in the current supported assembly, including remapping if necessary (`cluster`)
+4. Clustering in the current supported assembly, including remapping to that assembly if necessary (`optional_remap_and_cluster`)
 
 By default, the script will run all of these tasks, though you may specify a subset using the flag `--tasks`.
 Note that as some steps are long-running the script is best run in a screen/tmux session.

--- a/eva_submission/eload_ingestion.py
+++ b/eva_submission/eload_ingestion.py
@@ -421,6 +421,7 @@ class EloadIngestion(Eload):
         properties = self.properties_generator.get_clustering_properties(
             instance=instance,
             target_assembly=target_assembly,
+            projects=self.project_accession,
             rs_report_path=f'{target_assembly}_rs_report.txt'
         )
         with open(output_file_path, 'w') as open_file:

--- a/eva_submission/eload_ingestion.py
+++ b/eva_submission/eload_ingestion.py
@@ -394,7 +394,7 @@ class EloadIngestion(Eload):
             )
             results = get_all_results_for_query(conn, current_query)
             if len(results) > 0:
-                self.eload_cfg.set(self.config_section, 'clustering', 'target_assembly', value=results[0][0])
+                self.eload_cfg.set(self.config_section, 'remap_and_cluster', 'target_assembly', value=results[0][0])
                 return results[0][0]
         self.warning(f'Could not find any current supported assembly for {self.taxonomy}, skipping clustering')
         return None

--- a/eva_submission/eload_ingestion.py
+++ b/eva_submission/eload_ingestion.py
@@ -38,7 +38,7 @@ project_dirs = {
 
 class EloadIngestion(Eload):
     config_section = 'ingestion'  # top-level config key
-    all_tasks = ['metadata_load', 'accession', 'variant_load', 'annotation', 'cluster']
+    all_tasks = ['metadata_load', 'accession', 'variant_load', 'annotation', 'optional_remap_and_cluster']
     nextflow_complete_value = '<complete>'
 
     def __init__(self, eload_number, config_object: EloadConfig = None):
@@ -88,7 +88,7 @@ class EloadIngestion(Eload):
             self.update_files_with_ftp_path()
             self.refresh_study_browser()
 
-        if 'cluster' in tasks:
+        if 'optional_remap_and_cluster' in tasks:
             target_assembly = self._get_target_assembly()
             if target_assembly:
                 self.run_remap_and_cluster_workflow(target_assembly, resume=resume)

--- a/eva_submission/eload_ingestion.py
+++ b/eva_submission/eload_ingestion.py
@@ -13,6 +13,7 @@ from ebi_eva_common_pyutils.config_utils import get_mongo_uri_for_eva_profile, g
 from ebi_eva_common_pyutils.metadata_utils import resolve_variant_warehouse_db_name, insert_new_assembly_and_taxonomy, \
     get_assembly_set_from_metadata
 from ebi_eva_common_pyutils.pg_utils import get_all_results_for_query, execute_query
+from ebi_eva_common_pyutils.spring_properties import SpringPropertiesGenerator
 
 from eva_submission import NEXTFLOW_DIR
 from eva_submission.eload_submission import Eload
@@ -28,6 +29,7 @@ project_dirs = {
     'stats': '50_stats',
     'annotation': '51_annotation',
     'accessions': '52_accessions',
+    'clustering': '53_clustering',
     'public': '60_eva_public',
     'external': '70_external_submissions',
     'deprecated': '80_deprecated'
@@ -36,13 +38,17 @@ project_dirs = {
 
 class EloadIngestion(Eload):
     config_section = 'ingestion'  # top-level config key
-    all_tasks = ['metadata_load', 'accession', 'variant_load', 'annotation']
+    all_tasks = ['metadata_load', 'accession', 'variant_load', 'annotation', 'cluster']
     nextflow_complete_value = '<complete>'
 
     def __init__(self, eload_number, config_object: EloadConfig = None):
         super().__init__(eload_number, config_object)
         self.project_accession = self.eload_cfg.query('brokering', 'ena', 'PROJECT')
-        self.mongo_uri = get_mongo_uri_for_eva_profile(cfg['maven']['environment'], cfg['maven']['settings_file'])
+        self.taxonomy = self.eload_cfg.query('submission', 'taxonomy_id')
+        self.private_settings_file = cfg['maven']['settings_file']
+        self.maven_profile = cfg['maven']['environment']
+        self.mongo_uri = get_mongo_uri_for_eva_profile(self.maven_profile, self.private_settings_file)
+        self.properties_generator = SpringPropertiesGenerator(self.maven_profile, self.private_settings_file)
 
     def ingest(
             self,
@@ -81,6 +87,10 @@ class EloadIngestion(Eload):
             self.update_browsable_files_with_date()
             self.update_files_with_ftp_path()
             self.refresh_study_browser()
+
+        if 'cluster' in tasks:
+            target_assembly = self._get_target_assembly(self.taxonomy)
+            self.run_remap_and_cluster_workflow(target_assembly, resume=resume)
 
         if do_variant_load or annotation_only:
             self.run_variant_load_workflow(vcf_files_to_ingest, annotation_only, resume=resume)
@@ -143,12 +153,11 @@ class EloadIngestion(Eload):
         """
         Constructs the expected database name in mongo, based on assembly info retrieved from EVAPRO.
         """
-        taxon_id = self.eload_cfg.query('submission', 'taxonomy_id')
         # query EVAPRO for db name based on taxonomy id and accession
         with self.metadata_connection_handle as conn:
-            db_name = resolve_variant_warehouse_db_name(conn, assembly_accession, taxon_id)
+            db_name = resolve_variant_warehouse_db_name(conn, assembly_accession, self.taxonomy)
             if not db_name:
-                raise ValueError(f'Database name for taxid:{taxon_id} and assembly {assembly_accession} '
+                raise ValueError(f'Database name for taxid:{self.taxonomy} and assembly {assembly_accession} '
                                  f'could not be retrieved or constructed')
         return db_name
 
@@ -181,7 +190,7 @@ class EloadIngestion(Eload):
                 insert_new_assembly_and_taxonomy(
                     metadata_connection_handle=conn,
                     assembly_accession=assembly,
-                    taxonomy_id=self.eload_cfg.query('submission', 'taxonomy_id'),
+                    taxonomy_id=self.taxonomy,
                 )
 
         for db_info in assembly_to_db_name.values():
@@ -282,11 +291,11 @@ class EloadIngestion(Eload):
         return vcf_files_to_ingest
 
     def run_accession_workflow(self, vcf_files_to_ingest, resume):
-        mongo_host, mongo_user, mongo_pass = get_primary_mongo_creds_for_profile(cfg['maven']['environment'], cfg['maven']['settings_file'])
-        pg_url, pg_user, pg_pass = get_accession_pg_creds_for_profile(cfg['maven']['environment'], cfg['maven']['settings_file'])
-        counts_url, counts_user, counts_pass = get_count_service_creds_for_profile(cfg['maven']['environment'], cfg['maven']['settings_file'])
+        mongo_host, mongo_user, mongo_pass = get_primary_mongo_creds_for_profile(self.maven_profile, self.private_settings_file)
+        pg_url, pg_user, pg_pass = get_accession_pg_creds_for_profile(self.maven_profile, self.private_settings_file)
+        counts_url, counts_user, counts_pass = get_count_service_creds_for_profile(self.maven_profile, self.private_settings_file)
         job_props = accession_props_template(
-            taxonomy_id=self.eload_cfg.query('submission', 'taxonomy_id'),
+            taxonomy_id=self.taxonomy,
             project_accession=self.project_accession,
             instance_id=self.eload_cfg.query(self.config_section, 'accession', 'instance_id'),
             mongo_host=mongo_host,
@@ -334,6 +343,94 @@ class EloadIngestion(Eload):
             'annotation_only': annotation_only,
         }
         self.run_nextflow('variant_load', load_config, resume)
+
+    def run_remap_and_cluster_workflow(self, target_assembly, resume):
+        instance = self.eload_cfg.query(self.config_section, 'accession', 'instance_id')
+        scientific_name = self.eload_cfg.query('submission', 'scientific_name')
+        # this is where all the output will get stored - logs, properties, work dirs...
+        output_dir = os.path.join(self.project_dir, project_dirs['clustering'])
+
+        # TODO think about where this loop should occur, e.g. here or in nextflow
+        source_asms = self._get_assembly_accessions()
+        for source_assembly in source_asms:
+            extraction_properties_file = self.create_extraction_properties(
+                output_file_path=os.path.join(output_dir, 'remapping_extraction.properties'),
+                source_assembly=source_assembly,
+                taxonomy=self.taxonomy
+            )
+            ingestion_properties_file = self.create_ingestion_properties(
+                output_file_path=os.path.join(output_dir, 'remapping_ingestion.properties'),
+                source_assembly=source_assembly,
+                target_assembly=target_assembly
+            )
+            clustering_template_file = self.create_clustering_properties(
+                output_file_path=os.path.join(output_dir, 'clustering_template.properties'),
+                instance=instance,
+                source_assembly=source_assembly,
+                target_assembly=target_assembly
+            )
+
+            remap_cluster_config = {
+                'taxonomy_id': self.taxonomy,
+                'source_assembly_accession': source_assembly,
+                'target_assembly_accession': target_assembly,
+                'species_name': scientific_name,
+                'output_dir': output_dir,
+                'genome_assembly_dir': cfg['genome_downloader']['output_directory'],
+                'extraction_properties': extraction_properties_file,
+                'ingestion_properties': ingestion_properties_file,
+                'clustering_properties': clustering_template_file,
+                'clustering_instance': instance,
+                'remapping_config': cfg.config_file,
+                'remapping_required': source_assembly != target_assembly
+            }
+            for part in ['executable', 'nextflow', 'jar']:
+                remap_cluster_config[part] = cfg[part]
+            self.run_nextflow('remap_and_cluster', remap_cluster_config, resume)
+
+    def _get_target_assembly(self):
+        with self.metadata_connection_handle as conn:
+            current_query = (
+                f"SELECT assembly_id FROM evapro.supported_assembly_tracker "
+                f"WHERE taxonomy_id={self.taxonomy} AND current=true;"
+            )
+            results = get_all_results_for_query(conn, current_query)
+            if len(results) > 0:
+                return results[0][0]
+        # TODO what if we don't find anything?
+        raise ValueError(f'Could not find any current supported assembly for {self.taxonomy}, '
+                         f'please load the appropriate assembly before attempting clustering again')
+
+    def create_extraction_properties(self, output_file_path, source_assembly, taxonomy):
+        properties = self.properties_generator.get_remapping_extraction_properties(
+            taxonomy=taxonomy,
+            source_assembly=source_assembly,
+            projects=self.project_accession
+        )
+        with open(output_file_path, 'w') as open_file:
+            open_file.write(properties)
+        return output_file_path
+
+    def create_ingestion_properties(self, output_file_path, source_assembly, target_assembly):
+        properties = self.properties_generator.get_remapping_ingestion_properties(
+            source_assembly=source_assembly,
+            target_assembly=target_assembly,
+            load_to='EVA'
+        )
+        with open(output_file_path, 'w') as open_file:
+            open_file.write(properties)
+        return output_file_path
+
+    def create_clustering_properties(self, output_file_path, instance, source_assembly, target_assembly):
+        properties = self.properties_generator.get_clustering_properties(
+            instance=instance,
+            source_assembly=source_assembly,
+            target_assembly=target_assembly,
+            rs_report_path=f'{source_assembly}_to_{target_assembly}_rs_report.txt'
+        )
+        with open(output_file_path, 'w') as open_file:
+            open_file.write(properties)
+        return output_file_path
 
     def insert_browsable_files(self):
         with self.metadata_connection_handle as conn:
@@ -422,12 +519,11 @@ class EloadIngestion(Eload):
                                f'assembly_set_id {assembly_set_id} from browsable_file')
 
     def update_assembly_set_in_analysis(self):
-        taxonomy = self.eload_cfg.query('submission', 'taxonomy_id')
         analyses = self.eload_cfg.query('submission', 'analyses')
         with self.metadata_connection_handle as conn:
             for analysis_alias, analysis_data in analyses.items():
                 assembly_accession = analysis_data['assembly_accession']
-                assembly_set_id = get_assembly_set_from_metadata(conn, taxonomy, assembly_accession)
+                assembly_set_id = get_assembly_set_from_metadata(conn, self.taxonomy, assembly_accession)
                 analysis_accession = self.eload_cfg.query('brokering', 'ena', 'ANALYSIS', analysis_alias)
                 # Check if the update is needed
                 check_query = (f"select assembly_set_id from evapro.analysis "

--- a/eva_submission/eload_ingestion.py
+++ b/eva_submission/eload_ingestion.py
@@ -481,7 +481,7 @@ class EloadIngestion(Eload):
 
     def update_loaded_assembly_in_browsable_files(self):
         # find assembly associated with each browseable file and copy it to the browsable file table
-        query = ('select bf.file_id, a.vcf_reference_accession ' 
+        query = ('select bf.file_id, a.vcf_reference_accession '
                  'from analysis a '
                  'join analysis_file af on a.analysis_accession=af.analysis_accession '
                  'join browsable_file bf on af.file_id=bf.file_id '

--- a/eva_submission/nextflow/accession.nf
+++ b/eva_submission/nextflow/accession.nf
@@ -133,7 +133,7 @@ process create_properties {
  * Accession VCFs
  */
 process accession_vcf {
-    clusterOptions "-g /accession \
+    clusterOptions "-g /accession/instance-${params.instance_id} \
                     -o $params.logs_dir/${log_filename}.log \
                     -e $params.logs_dir/${log_filename}.err"
 

--- a/eva_submission/nextflow/accession.nf
+++ b/eva_submission/nextflow/accession.nf
@@ -133,7 +133,7 @@ process create_properties {
  * Accession VCFs
  */
 process accession_vcf {
-    clusterOptions "-g /accession/instance-${params.instance_id} \
+    clusterOptions "-g /accession \
                     -o $params.logs_dir/${log_filename}.log \
                     -e $params.logs_dir/${log_filename}.err"
 

--- a/eva_submission/nextflow/remap_and_cluster.nf
+++ b/eva_submission/nextflow/remap_and_cluster.nf
@@ -212,7 +212,7 @@ process ingest_vcf_into_mongo {
  */
 process cluster_studies_from_mongo {
     memory "${params.memory}GB"
-    clusterOptions "-g /accession/instance-${params.instance_id}"
+    clusterOptions "-g /accession/instance-${params.clustering_instance}"
 
     input:
     path ingestion_log from empty_ch.mix(ingestion_log_filename.collect())

--- a/eva_submission/nextflow/remap_and_cluster.nf
+++ b/eva_submission/nextflow/remap_and_cluster.nf
@@ -212,7 +212,7 @@ process ingest_vcf_into_mongo {
  */
 process cluster_studies_from_mongo {
     memory "${params.memory}GB"
-    clusterOptions "-g /accession"
+    clusterOptions "-g /accession/instance-${params.instance_id}"
 
     input:
     path ingestion_log from empty_ch.mix(ingestion_log_filename.collect())

--- a/eva_submission/nextflow/remap_and_cluster.nf
+++ b/eva_submission/nextflow/remap_and_cluster.nf
@@ -1,0 +1,252 @@
+#!/usr/bin/env nextflow
+
+def helpMessage() {
+    log.info"""
+    Remap a single study from one assembly version to another, cluster, and QC.
+
+    Inputs:
+            --taxonomy_id                   taxonomy id of submitted variants that needs to be remapped.
+            --source_assembly_accession     assembly accession of the submitted variants are currently mapped to.
+            --target_assembly_accession     assembly accession the submitted variants will be remapped to.
+            --species_name                  scientific name to be used for the species.
+            --genome_assembly_dir           path to the directory where the genome should be downloaded.
+            --extraction_properties         path to extraction properties file
+            --ingestion_properties          path to remapping ingestion properties file
+            --clustering_properties         path to clustering properties file
+            --clustering_instance           instance id to use for clustering
+            --output_dir                    path to the directory where the output file should be copied.
+            --remapping_config              path to the remapping configuration file
+            --remapping_required            flag that sets the remapping as required if true otherwise the remapping is skipped and only the clustering can be run
+    """
+}
+
+params.source_assembly_accession = null
+params.target_assembly_accession = null
+params.species_name = null
+params.memory = 8
+// help
+params.help = null
+
+// Show help message
+if (params.help) exit 0, helpMessage()
+
+// Test input files
+if (!params.taxonomy_id || !params.source_assembly_accession || !params.target_assembly_accession || !params.species_name || !params.genome_assembly_dir ) {
+    if (!params.taxonomy_id) log.warn('Provide the taxonomy id of the source submitted variants using --taxonomy_id')
+    if (!params.source_assembly_accession) log.warn('Provide the source assembly using --source_assembly_accession')
+    if (!params.target_assembly_accession) log.warn('Provide the target assembly using --target_assembly_accession')
+    if (!params.species_name) log.warn('Provide a species name using --species_name')
+    if (!params.genome_assembly_dir) log.warn('Provide a path to where the assembly should be downloaded using --genome_assembly_dir')
+    exit 1, helpMessage()
+}
+
+species_name = params.species_name.toLowerCase().replace(" ", "_")
+source_to_target = "${params.source_assembly_accession}_to_${params.target_assembly_accession}"
+
+// Create an channel that will either be empty if remapping will take place or contain a dummy value if not
+// This will allow to trigger the clustering even if no remapping is required
+// We're using params.genome_assembly_dir because cluster_studies_from_mongo needs to receive a file object
+empty_ch = params.remapping_required ? Channel.empty() : Channel.of(params.genome_assembly_dir)
+
+process retrieve_source_genome {
+
+    output:
+    path "${params.source_assembly_accession}.fa" into source_fasta
+    path "${params.source_assembly_accession}_assembly_report.txt" into source_report
+
+    """
+    $params.executable.genome_downloader --assembly-accession ${params.source_assembly_accession} --species ${species_name} --output-directory ${params.genome_assembly_dir}
+    ln -s ${params.genome_assembly_dir}/${species_name}/${params.source_assembly_accession}/${params.source_assembly_accession}.fa
+    ln -s ${params.genome_assembly_dir}/${species_name}/${params.source_assembly_accession}/${params.source_assembly_accession}_assembly_report.txt
+    """
+}
+
+
+process retrieve_target_genome {
+
+    output:
+    path "${params.target_assembly_accession}.fa" into target_fasta
+    path "${params.target_assembly_accession}_assembly_report.txt" into target_report
+
+    """
+    $params.executable.genome_downloader --assembly-accession ${params.target_assembly_accession} --species ${species_name} --output-directory ${params.genome_assembly_dir}
+    ln -s ${params.genome_assembly_dir}/${species_name}/${params.target_assembly_accession}/${params.target_assembly_accession}.fa
+    ln -s ${params.genome_assembly_dir}/${species_name}/${params.target_assembly_accession}/${params.target_assembly_accession}_assembly_report.txt
+    """
+}
+
+process update_source_genome {
+
+    input:
+    path source_fasta from source_fasta
+    path source_report from source_report
+    env REMAPPINGCONFIG from params.remapping_config
+
+    output:
+    path  "${source_fasta.getBaseName()}_custom.fa" into updated_source_fasta
+    path  "${source_report.getBaseName()}_custom.txt" into updated_source_report
+
+    """
+    ${params.executable.custom_assembly} --assembly-accession ${params.source_assembly_accession} --fasta-file ${source_fasta} --report-file ${source_report}
+    """
+}
+
+process update_target_genome {
+
+    input:
+    path target_fasta from target_fasta
+    path target_report from target_report
+    env REMAPPINGCONFIG from params.remapping_config
+
+    output:
+    path "${target_fasta.getBaseName()}_custom.fa" into updated_target_fasta
+    path "${target_report.getBaseName()}_custom.txt" into updated_target_report
+
+    """
+    ${params.executable.custom_assembly} --assembly-accession ${params.target_assembly_accession} --fasta-file ${target_fasta} --report-file ${target_report} --no-rename
+    """
+}
+
+
+/*
+ * Extract the submitted variants to remap from the accesioning warehouse and store them in a VCF file.
+ */
+process extract_vcf_from_mongo {
+    memory "${params.memory}GB"
+    clusterOptions "-g /accession"
+
+    when:
+    params.remapping_required
+
+    input:
+    path source_fasta from updated_source_fasta
+    path source_report from updated_source_report
+
+    output:
+    // Only pass on the EVA vcf
+    path "${params.source_assembly_accession}_eva.vcf" into source_vcfs
+    path "${params.source_assembly_accession}_vcf_extractor.log" into log_filename
+
+    publishDir "$params.output_dir/logs", overwrite: true, mode: "copy", pattern: "*.log*"
+
+    """
+    java -Xmx8G -jar $params.jar.vcf_extractor \
+        --spring.config.location=file:${params.extraction_properties} \
+        --parameters.fasta=${source_fasta} \
+        --parameters.assemblyReportUrl=file:${source_report} \
+        > ${params.source_assembly_accession}_vcf_extractor.log
+    """
+}
+
+
+/*
+ * Variant remapping pipeline
+ */
+process remap_variants {
+    memory "${params.memory}GB"
+
+    input:
+    path source_fasta from updated_source_fasta
+    path target_fasta from updated_target_fasta
+    path source_vcf from source_vcfs.flatten()
+
+    output:
+    path "${basename_source_vcf}_remapped.vcf" into remapped_vcfs
+    path "${basename_source_vcf}_remapped_unmapped.vcf" into unmapped_vcfs
+    path "${basename_source_vcf}_remapped_counts.yml" into remapped_ymls
+
+    publishDir "$params.output_dir/eva", overwrite: true, mode: "copy", pattern: "*_eva_remapped*"
+
+    script:
+    basename_source_vcf = source_vcf.getBaseName()
+    """
+    # Setup the PATH so that the variant remapping pipeline can access its dependencies
+    mkdir bin
+    for P in $params.executable.bcftools $params.executable.samtools $params.executable.bedtools $params.executable.minimap2 $params.executable.bgzip $params.executable.tabix
+      do ln -s \$P bin/
+    done
+    PATH=`pwd`/bin:\$PATH
+    source $params.executable.python_activate
+    # Nextflow needs the full path to the input parameters hence the pwd
+    $params.executable.nextflow run $params.nextflow.remapping -resume \
+      --oldgenome `pwd`/${source_fasta} \
+      --newgenome `pwd`/${target_fasta} \
+      --vcffile `pwd`/${source_vcf} \
+      --outfile `pwd`/${basename_source_vcf}_remapped.vcf
+    """
+}
+
+
+/*
+ * Ingest the remapped submitted variants from a VCF file into the accessioning warehouse.
+ */
+process ingest_vcf_into_mongo {
+    memory "${params.memory}GB"
+    clusterOptions "-g /accession"
+
+    input:
+    path remapped_vcf from remapped_vcfs.flatten()
+    path target_report from updated_target_report
+
+    output:
+    path "${remapped_vcf}_ingestion.log" into ingestion_log_filename
+
+    publishDir "$params.output_dir/logs", overwrite: true, mode: "copy", pattern: "*.log*"
+
+    script:
+    """
+    java -Xmx8G -jar $params.jar.vcf_ingestion \
+        --spring.config.location=file:${params.ingestion_properties} \
+        --parameters.vcf=${remapped_vcf} \
+        --parameters.assemblyReportUrl=file:${target_report} \
+        > ${remapped_vcf}_ingestion.log
+    """
+}
+
+
+/*
+ * Cluster target assembly.
+ */
+process cluster_studies_from_mongo {
+    memory "${params.memory}GB"
+    clusterOptions "-g /accession"
+
+    input:
+    path ingestion_log from empty_ch.mix(ingestion_log_filename.collect())
+
+    output:
+    path "${source_to_target}_clustering.log" into clustering_log_filename
+    path "${source_to_target}_rs_report.txt" optional true into rs_report_filename
+
+    publishDir "$params.output_dir/logs", overwrite: true, mode: "copy", pattern: "*.log*"
+
+    """
+    java -Xmx8G -jar $params.jar.clustering \
+        --spring.config.location=file:${params.clustering_properties} \
+        --spring.batch.job.names=STUDY_CLUSTERING_JOB \
+        > ${source_to_target}_clustering.log
+    """
+}
+
+/*
+ * Run clustering QC job
+ */
+process qc_clustering {
+    memory "${params.memory}GB"
+    clusterOptions "-g /accession"
+
+    input:
+    path rs_report from rs_report_filename
+
+    output:
+    path "${source_to_target}_clustering_qc.log" into clustering_qc_log_filename
+
+    publishDir "$params.output_dir/logs", overwrite: true, mode: "copy", pattern: "*.log*"
+
+    """
+    java -Xmx8G -jar $params.jar.clustering \
+        --spring.config.location=file:${params.clustering_properties} \
+        --spring.batch.job.names=NEW_CLUSTERED_VARIANTS_QC_JOB \
+        > ${source_to_target}_clustering_qc.log
+    """
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cached-property
 cerberus
-ebi-eva-common-pyutils>=0.4.0
+ebi-eva-common-pyutils>=0.5.1
 eva-vcf-merge>=0.0.6
 humanize
 lxml

--- a/tests/nextflow-tests/bin/fake_custom_assembly.py
+++ b/tests/nextflow-tests/bin/fake_custom_assembly.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+import argparse
+
+
+def touch(f):
+    open(f, 'w').close()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-a", "--assembly-accession", required=True)
+    parser.add_argument("-f", "--fasta-file", required=True)
+    parser.add_argument("-r", "--report-file", required=True)
+    parser.add_argument("--no-rename", action='store_true')
+    args = parser.parse_args()
+    touch(args.fasta_file.replace('.fa', '_custom.fa'))
+    touch(args.report_file.replace('.txt', '_custom.txt'))

--- a/tests/nextflow-tests/bin/fake_genome_downloader.py
+++ b/tests/nextflow-tests/bin/fake_genome_downloader.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+import argparse
+import os
+
+
+def touch(f):
+    open(f, 'w').close()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-a", "--assembly-accession", required=True)
+    parser.add_argument("-s", "--species", required=True)
+    parser.add_argument("-o", "--output-directory")
+    args = parser.parse_args()
+    d = os.path.join(args.output_directory, args.species.lower().replace(' ', '_'), args.assembly_accession)
+    os.makedirs(d, exist_ok=True)
+    touch(os.path.join(d, args.assembly_accession + '.fa'))
+    touch(os.path.join(d, args.assembly_accession + '_assembly_report.txt'))

--- a/tests/nextflow-tests/bin/fake_remapping_pipeline.nf
+++ b/tests/nextflow-tests/bin/fake_remapping_pipeline.nf
@@ -1,0 +1,22 @@
+#!/usr/bin/env nextflow
+
+
+outfile_basename = file(params.outfile).getName()
+outfile_no_extension = file(params.outfile).getBaseName()
+
+process remap_vcf {
+
+    publishDir workflow.launchDir
+
+    output:
+    path "${outfile_basename}" into remapped_vcf
+    path "${outfile_no_extension}_counts.yml" into remapped_yml
+    path "${outfile_no_extension}_unmapped.vcf" into unmapped_vcf
+
+    script:
+    """
+    touch ${outfile_basename}
+    touch ${outfile_no_extension}_counts.yml
+    touch ${outfile_no_extension}_unmapped.vcf
+    """
+}

--- a/tests/nextflow-tests/build_tests.sh
+++ b/tests/nextflow-tests/build_tests.sh
@@ -13,4 +13,13 @@ jar cfe accession.jar FakeAccessionPipeline FakeAccessionPipeline.class
 javac FakeVariantLoadPipeline.java
 jar cfe variant-load.jar FakeVariantLoadPipeline FakeVariantLoadPipeline.class
 
+javac FakeRemappingExtractionPipeline.java
+jar cfe extraction.jar FakeRemappingExtractionPipeline FakeRemappingExtractionPipeline.class
+
+javac FakeRemappingLoadingPipeline.java
+jar cfe remap-loading.jar FakeRemappingLoadingPipeline FakeRemappingLoadingPipeline.class
+
+javac FakeClusteringPipeline.java
+jar cfe clustering.jar FakeClusteringPipeline FakeClusteringPipeline.class
+
 cd ${cwd}

--- a/tests/nextflow-tests/java/FakeClusteringPipeline.java
+++ b/tests/nextflow-tests/java/FakeClusteringPipeline.java
@@ -1,0 +1,12 @@
+
+public class FakeClusteringPipeline {
+    
+    public static void main(String[] args) {
+	String outString = "java -jar clustering.jar";
+	for (String arg: args) {
+	    outString += " " + arg;
+	}
+	System.out.println(outString);
+    }
+
+}

--- a/tests/nextflow-tests/java/FakeRemappingExtractionPipeline.java
+++ b/tests/nextflow-tests/java/FakeRemappingExtractionPipeline.java
@@ -1,0 +1,29 @@
+import java.io.FileWriter;
+import java.io.IOException;
+
+
+public class FakeRemappingExtractionPipeline {
+    
+    public static void main(String[] args) {
+        String outString = "java -jar extraction.jar";
+        String inFile = null;
+        for (String arg: args) {
+            outString += " " + arg;
+            if (arg.startsWith("--parameters.fasta="))
+            inFile = arg.substring("--parameters.fasta=".length(), arg.length()-"_custom.fa".length());
+        }
+        System.out.println(outString);
+        System.out.println(inFile);
+
+        // real pipeline gets this from properties
+	    String outFile2 =  inFile + "_eva.vcf";
+        try {
+            FileWriter writer = new FileWriter(outFile2);
+            writer.write("remapped eva variants\n");
+            writer.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+	    }
+    }
+
+}

--- a/tests/nextflow-tests/java/FakeRemappingLoadingPipeline.java
+++ b/tests/nextflow-tests/java/FakeRemappingLoadingPipeline.java
@@ -1,0 +1,12 @@
+
+public class FakeRemappingLoadingPipeline {
+    
+    public static void main(String[] args) {
+        String outString = "java -jar remap-loading.jar";
+        for (String arg: args) {
+            outString += " " + arg;
+        }
+        System.out.println(outString);
+    }
+
+}

--- a/tests/nextflow-tests/run_tests_clustering.sh
+++ b/tests/nextflow-tests/run_tests_clustering.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SOURCE_DIR="$(dirname $(dirname $SCRIPT_DIR))/eva_submission/nextflow"
+
+cwd=${PWD}
+cd ${SCRIPT_DIR}
+mkdir -p project project/accessions project/public ftp
+
+printf "\e[32m==== REMAP AND CLUSTER PIPELINE ====\e[0m\n"
+nextflow run ${SOURCE_DIR}/remap_and_cluster.nf -params-file test_ingestion_config.yaml \
+   --taxonomy_id 1234 \
+	 --species_name "Thingy thungus" \
+	 --genome_assembly_dir ${SCRIPT_DIR}/genomes \
+	 --extraction_properties ${SCRIPT_DIR}/template.properties \
+	 --ingestion_properties ${SCRIPT_DIR}/template.properties \
+	 --clustering_properties ${SCRIPT_DIR}/template.properties \
+	 --clustering_instance 1 \
+	 --output_dir ${SCRIPT_DIR}/output \
+	 --remapping_config ${SCRIPT_DIR}/test_ingestion_config.yaml \
+	 --memory 2
+
+# Two remappings
+printf "\e[32m====== Remapping files ======\e[0m\n"
+ls ${SCRIPT_DIR}/output/eva/GCA_0000001_eva_remapped.vcf \
+   ${SCRIPT_DIR}/output/eva/GCA_0000001_eva_remapped_unmapped.vcf \
+   ${SCRIPT_DIR}/output/eva/GCA_0000001_eva_remapped_counts.yml \
+   ${SCRIPT_DIR}/output/eva/GCA_0000002_eva_remapped.vcf \
+   ${SCRIPT_DIR}/output/eva/GCA_0000002_eva_remapped_unmapped.vcf \
+   ${SCRIPT_DIR}/output/eva/GCA_0000002_eva_remapped_counts.yml
+
+# Test we have 5 log files in the logs directory (2 extraction, 2 ingestion, 1 clustering)
+[[ $(find ${SCRIPT_DIR}/output/logs/ -type f -name "*.log" | wc -l) -eq 5 ]]
+printf "\e[32m====== Remapping and clustering logs ======\e[0m\n"
+ls ${SCRIPT_DIR}/output/logs/GCA_0000001_vcf_extractor.log \
+   ${SCRIPT_DIR}/output/logs/GCA_0000001_eva_remapped.vcf_ingestion.log \
+   ${SCRIPT_DIR}/output/logs/GCA_0000002_vcf_extractor.log \
+   ${SCRIPT_DIR}/output/logs/GCA_0000002_eva_remapped.vcf_ingestion.log \
+   ${SCRIPT_DIR}/output/logs/GCA_0000003_clustering.log
+
+# clean up
+rm -rf work .nextflow*
+rm -r output genomes
+cd ${cwd}

--- a/tests/nextflow-tests/test_ingestion_config.yaml
+++ b/tests/nextflow-tests/test_ingestion_config.yaml
@@ -6,6 +6,12 @@ public_dir: ../../../project/public
 valid_vcfs: vcf_files_to_ingest.csv
 vep_path: /path/to/vep
 
+source_assemblies:
+  - GCA_0000001
+  - GCA_0000002
+  - GCA_0000003
+target_assembly_accession: GCA_0000003
+
 accession_job_props:
   test.prop1: x
   test.prop2: y
@@ -19,6 +25,20 @@ executable:
   bcftools: ../../../bin/fake_bcftools.sh
   bgzip: ../../../bin/fake_bgzip.sh
   tabix: ../../../bin/fake_tabix.sh
+  samtools: samtools
+  bedtools: bedtools
+  minimap2: minimap2
+  nextflow: nextflow
+  genome_downloader: ../../../bin/fake_genome_downloader.py
+  custom_assembly: ../../../bin/fake_custom_assembly.py
+  python_activate: ../../../bin/venv_activate
+
+nextflow:
+  remapping: ../../../bin/fake_remapping_pipeline.nf
+
 jar:
   accession_pipeline: ../../../java/accession.jar
   eva_pipeline: ../../../java/variant-load.jar
+  vcf_extractor: ../../../java/extraction.jar
+  vcf_ingestion: ../../../java/remap-loading.jar
+  clustering: ../../../java/clustering.jar

--- a/tests/resources/settings.xml
+++ b/tests/resources/settings.xml
@@ -15,6 +15,7 @@
                 <eva.accession.jdbc.url>host</eva.accession.jdbc.url>
                 <eva.accession.user>user</eva.accession.user>
                 <eva.accession.password>pass</eva.accession.password>
+                <eva.accession.mongo.database>accession</eva.accession.mongo.database>
                 <contig-alias.url>host</contig-alias.url>
                 <contig-alias.admin-user>user</contig-alias.admin-user>
                 <contig-alias.admin-password>pass</contig-alias.admin-password>

--- a/tests/resources/submission_config.yml
+++ b/tests/resources/submission_config.yml
@@ -34,6 +34,9 @@ jar:
   accession_pipeline: /path/to/accession_pipeline.jar
   eva_pipeline: /path/to/eva_pipeline.jar
 
+nextflow:
+  remapping: /path/to/remapping.nf
+
 ena:
   submit_url: https://www-test.ebi.ac.uk/ena/submit/drop-box/submit/
   submit_async: https://wwwdev.ebi.ac.uk/ena/submit/webin-v2/submit/queue

--- a/tests/test_eload_ingestion.py
+++ b/tests/test_eload_ingestion.py
@@ -372,7 +372,7 @@ class TestEloadIngestion(TestCase):
                 patch('eva_submission.eload_ingestion.command_utils.run_command_with_output', autospec=True) as m_run_command, \
                 self._patch_mongo_database():
             m_get_results.side_effect = default_db_results_for_clustering()
-            self.eload.ingest(tasks=['cluster'])
+            self.eload.ingest(tasks=['optional_remap_and_cluster'])
             assert self.eload.eload_cfg.query('ingestion', 'remap_and_cluster', 'target_assembly') == 'GCA_123'
             assert m_run_command.call_count == 1
 
@@ -382,7 +382,7 @@ class TestEloadIngestion(TestCase):
                 patch('eva_submission.eload_ingestion.command_utils.run_command_with_output', autospec=True) as m_run_command, \
                 self._patch_mongo_database():
             m_get_results.return_value = []
-            self.eload.ingest(tasks=['cluster'])
+            self.eload.ingest(tasks=['optional_remap_and_cluster'])
             assert self.eload.eload_cfg.query('ingestion', 'remap_and_cluster', 'target_assembly') is None
             assert m_run_command.call_count == 0
 

--- a/tests/test_eload_ingestion.py
+++ b/tests/test_eload_ingestion.py
@@ -373,7 +373,7 @@ class TestEloadIngestion(TestCase):
                 self._patch_mongo_database():
             m_get_results.side_effect = default_db_results_for_clustering()
             self.eload.ingest(tasks=['cluster'])
-            assert self.eload.eload_cfg.query('ingestion', 'clustering', 'target_assembly') == 'GCA_123'
+            assert self.eload.eload_cfg.query('ingestion', 'remap_and_cluster', 'target_assembly') == 'GCA_123'
             assert m_run_command.call_count == 1
 
     def test_ingest_clustering_no_supported_assembly(self):
@@ -383,7 +383,7 @@ class TestEloadIngestion(TestCase):
                 self._patch_mongo_database():
             m_get_results.return_value = []
             self.eload.ingest(tasks=['cluster'])
-            assert self.eload.eload_cfg.query('ingestion', 'clustering', 'target_assembly') is None
+            assert self.eload.eload_cfg.query('ingestion', 'remap_and_cluster', 'target_assembly') is None
             assert m_run_command.call_count == 0
 
     def test_resume_when_step_fails(self):

--- a/tests/test_eload_ingestion.py
+++ b/tests/test_eload_ingestion.py
@@ -32,10 +32,17 @@ def default_db_results_for_variant_load():
     ]
 
 
+def default_db_results_for_clustering():
+    return [
+        [('GCA_123',)]  # current supported assembly
+    ]
+
+
 def default_db_results_for_ingestion():
     return (
             default_db_results_for_metadata_load()
             + default_db_results_for_accession()
+            + default_db_results_for_clustering()
             + default_db_results_for_variant_load()
     )
 
@@ -359,6 +366,26 @@ class TestEloadIngestion(TestCase):
                 os.path.join(self.resources_folder, 'projects/PRJEB12345/variant_load_params.yaml')
             )
 
+    def test_ingest_clustering(self):
+        with self._patch_metadata_handle(), \
+                patch('eva_submission.eload_ingestion.get_all_results_for_query') as m_get_results, \
+                patch('eva_submission.eload_ingestion.command_utils.run_command_with_output', autospec=True) as m_run_command, \
+                self._patch_mongo_database():
+            m_get_results.side_effect = default_db_results_for_clustering()
+            self.eload.ingest(tasks=['cluster'])
+            assert self.eload.eload_cfg.query('ingestion', 'clustering', 'target_assembly') == 'GCA_123'
+            assert m_run_command.call_count == 1
+
+    def test_ingest_clustering_no_supported_assembly(self):
+        with self._patch_metadata_handle(), \
+                patch('eva_submission.eload_ingestion.get_all_results_for_query') as m_get_results, \
+                patch('eva_submission.eload_ingestion.command_utils.run_command_with_output', autospec=True) as m_run_command, \
+                self._patch_mongo_database():
+            m_get_results.return_value = []
+            self.eload.ingest(tasks=['cluster'])
+            assert self.eload.eload_cfg.query('ingestion', 'clustering', 'target_assembly') is None
+            assert m_run_command.call_count == 0
+
     def test_resume_when_step_fails(self):
         with self._patch_metadata_handle(), \
                 patch('eva_submission.eload_ingestion.get_all_results_for_query') as m_get_results, \
@@ -378,6 +405,7 @@ class TestEloadIngestion(TestCase):
                 subprocess.CalledProcessError(1, 'nextflow accession'),  # first accession fails
                 None,  # metadata load on resume
                 None,  # accession on resume
+                None,  # clustering
                 None,  # variant load
             ]
 
@@ -406,13 +434,13 @@ class TestEloadIngestion(TestCase):
             # Resuming with no existing job execution is fine
             self.eload.ingest(resume=True)
             num_db_calls = m_get_results.call_count
-            assert m_run_command.call_count == 3
+            assert m_run_command.call_count == 4
 
             # If we resume a successfully completed job, everything in the python will re-run (including db queries)
             # but the nextflow calls will not
             self.eload.ingest(resume=True)
             assert m_get_results.call_count == 2*num_db_calls
-            assert m_run_command.call_count == 4  # 3+1 for metadata
+            assert m_run_command.call_count == 5  # 1 per task, plus 1 for metadata
 
     def test_resume_with_tasks(self):
         with self._patch_metadata_handle(), \


### PR DESCRIPTION
The nextflow pipeline should look very similar to the one from eva-tools, just modified to run the remapping processes for multiple source assemblies if present in the project.

Also I think `eload_ingestion.py` is in need of a bit of a refactor, but that's for another time...