### PR TITLE
Fix Nextflow paths

### DIFF
--- a/eva_submission/nextflow/accession.nf
+++ b/eva_submission/nextflow/accession.nf
@@ -102,7 +102,7 @@ workflow {
  */
 process create_properties {
     input:
-    tuple path(vcf_file), val(assembly_accession), val(aggregation), path(fasta), path(report)
+    tuple val(vcf_file), val(assembly_accession), val(aggregation), val(fasta), val(report)
 
     output:
     path "${vcf_file.getFileName()}_accessioning.properties", emit: accession_props

--- a/eva_submission/nextflow/variant_load.nf
+++ b/eva_submission/nextflow/variant_load.nf
@@ -76,7 +76,7 @@ workflow {
  */
 process create_properties {
     input:
-    tuple val(vcf_file), path(fasta), val(analysis_accession), val(db_name), val(vep_version), val(vep_cache_version), val(vep_species), val(aggregation)
+    tuple val(vcf_file), val(fasta), val(analysis_accession), val(db_name), val(vep_version), val(vep_cache_version), val(vep_species), val(aggregation)
 
     output:
     path "load_${vcf_file.getFileName()}.properties", emit: variant_load_props
@@ -149,7 +149,7 @@ process load_vcf {
  */
 process create_properties_for_acc_import_job {
     input:
-    tuple path(vcf_file), val(db_name)
+    tuple val(vcf_file), val(db_name)
 
     output:
     path "${acc_import_property_file_name}", emit: accession_import_props

--- a/tests/nextflow-tests/vcf_files_to_ingest.csv
+++ b/tests/nextflow-tests/vcf_files_to_ingest.csv
@@ -1,4 +1,4 @@
 vcf_file,assembly_accession,fasta,report,analysis_accession,db_name,vep_version,vep_cache_version,vep_secies,aggregation
-vcfs/test1.vcf.gz,GCA_000001000.1,fasta.fa,assembly_report.txt,ERZ12345,db1,100,100,homo_sapiens,none
-vcfs/test2.vcf.gz,GCA_000001000.1,fasta.fa,assembly_report.txt,ERZ12345,db1,100,100,homo_sapiens,none
-vcfs/test3.vcf.gz,GCA_000001000.1,fasta.fa,assembly_report.txt,ERZ12346,db2,,,,none
+vcfs/test1.vcf.gz,GCA_000001000.1,/path/to/fasta.fa,/path/to/assembly_report.txt,ERZ12345,db1,100,100,homo_sapiens,none
+vcfs/test2.vcf.gz,GCA_000001000.1,/path/to/fasta.fa,/path/to/assembly_report.txt,ERZ12345,db1,100,100,homo_sapiens,none
+vcfs/test3.vcf.gz,GCA_000001000.1,/path/to/fasta.fa,/path/to/assembly_report.txt,ERZ12346,db2,,,,none


### PR DESCRIPTION
Set full path in nextflow test to make sure they are used as full path in the accession and variant load

Change the path to val to keep the original path