### PR TITLE
EVA-3471: Update Biosamples with creation/update process

### DIFF
--- a/bin/check_sample_exist.py
+++ b/bin/check_sample_exist.py
@@ -15,12 +15,11 @@
 # limitations under the License.
 
 import argparse
-import logging
 
 from ebi_eva_common_pyutils.config import cfg
 from ebi_eva_common_pyutils.logger import logging_config as log_cfg
 
-from eva_submission.biosamples_submission import AAPHALCommunicator
+from eva_submission.biosample_submission.biosamples_submitters import AAPHALCommunicator
 from eva_submission.submission_config import load_config
 
 

--- a/bin/modify_existing_sample.py
+++ b/bin/modify_existing_sample.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+# Copyright 2023 EMBL - European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import logging
+
+from ebi_eva_common_pyutils.config import cfg
+from ebi_eva_common_pyutils.logger import logging_config as log_cfg
+
+from eva_submission.biosamples_submission import AAPHALCommunicator, SampleMetadataSubmitter, BioSamplesSubmitter
+from eva_submission.submission_config import load_config
+
+
+def main():
+    arg_parser = argparse.ArgumentParser(
+        description='Update an existing BioSample using information present in a Spreadsheet. '
+                    'The spreadsheet needs to contain a Sheet called Sample.')
+    arg_parser.add_argument('--metadata_file', required=True,
+                            help='Spreadsheet file containing the sample information')
+    arg_parser.add_argument('--action', required=True, choices=('overwrite', 'curate', 'derive'),
+                            help='Type of modification of the BioSamples that should be made. '
+                                 '"overwrite" require that EVA owns the BioSample entity. '
+                                 '"curate" will create curation object on top of the BioSample. These are not '
+                                 'used by ENA. '
+                                 '"derive" will create a new BioSample derived from the old one.')
+    args = arg_parser.parse_args()
+
+    log_cfg.add_stdout_handler()
+
+    # Load the config_file from default location
+    load_config()
+    sample_submitter = SampleMetadataSubmitter(args.metadata_file, submit_type=(args.action,))
+    sample_submitter.submit_to_bioSamples()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/modify_existing_sample.py
+++ b/bin/modify_existing_sample.py
@@ -15,12 +15,10 @@
 # limitations under the License.
 
 import argparse
-import logging
 
-from ebi_eva_common_pyutils.config import cfg
 from ebi_eva_common_pyutils.logger import logging_config as log_cfg
 
-from eva_submission.biosamples_submission import AAPHALCommunicator, SampleMetadataSubmitter, BioSamplesSubmitter
+from eva_submission.biosample_submission.biosamples_submitters import SampleMetadataSubmitter
 from eva_submission.submission_config import load_config
 from eva_submission.xlsx.xlsx_parser_eva import EvaXlsxWriter, EvaXlsxReader
 
@@ -46,6 +44,7 @@ def main():
     sample_submitter = SampleMetadataSubmitter(args.metadata_file, submit_type=(args.action,))
     sample_name_to_accession = sample_submitter.submit_to_bioSamples()
     if args.action == 'derive':
+        # When deriving samples we need to copy the resulting accessions in the spreadsheet.
         eva_xls_reader = EvaXlsxReader(args.metadata_file)
         eva_xls_writer = EvaXlsxWriter(args.metadata_file)
         sample_rows = []

--- a/eva_submission/biosample_submission/biosamples_communicators.py
+++ b/eva_submission/biosample_submission/biosamples_communicators.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python
+# Copyright 2020 EMBL - European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+
+import requests
+from cached_property import cached_property
+from ebi_eva_common_pyutils.logger import AppLogger
+from retry import retry
+
+
+class HALNotReadyError(Exception):
+    pass
+
+
+class HALCommunicator(AppLogger):
+    """
+    This class helps navigate through REST API that uses the HAL standard.
+    """
+    acceptable_code = [200, 201]
+
+    def __init__(self, auth_url, bsd_url, username, password):
+        self.auth_url = auth_url
+        self.bsd_url = bsd_url
+        self.username = username
+        self.password = password
+
+    def _validate_response(self, response):
+        """Check that the response has an acceptable code and raise if it does not"""
+        if response.status_code not in self.acceptable_code:
+            self.error(response.request.method + ': ' + response.request.url + " with " + str(response.request.body))
+            self.error("headers: {}".format(response.request.headers))
+            self.error("<{}>: {}".format(response.status_code, response.text))
+            raise ValueError('The HTTP status code ({}) is not one of the acceptable codes ({})'.format(
+                str(response.status_code), str(self.acceptable_code))
+            )
+        return response
+
+    @cached_property
+    def token(self):
+        """Retrieve the token from the AAP REST API then cache it for further quering"""
+        response = requests.get(self.auth_url, auth=(self.username, self.password))
+        self._validate_response(response)
+        return response.text
+
+    @retry(exceptions=(ValueError, requests.RequestException), tries=3, delay=2, backoff=1.2, jitter=(1, 3))
+    def _req(self, method, url, **kwargs):
+        """private method that sends a request using the specified method. It adds the headers required by bsd"""
+        headers = kwargs.pop('headers', {})
+        headers.update({'Accept': 'application/hal+json', 'Authorization': 'Bearer ' + self.token})
+        if 'json' in kwargs:
+            headers['Content-Type'] = 'application/json'
+        response = requests.request(
+            method=method,
+            url=url,
+            headers=headers,
+            **kwargs
+        )
+        self._validate_response(response)
+        return response
+
+    def follows(self, query, json_obj=None, method='GET', url_template_values=None, join_url=None, **kwargs):
+        """
+        Finds a link within the json_obj using a query string or list, modify the link using the
+        url_template_values dictionary then query the link using the method and any additional keyword argument.
+        If the json_obj is not specified then it will use the root query defined by the base url.
+        """
+        all_pages = kwargs.pop('all_pages', False)
+
+        if json_obj is None:
+            json_obj = self.root
+        # Drill down into a dict using dot notation
+        _json_obj = json_obj
+        if isinstance(query, str):
+            query_list = query.split('.')
+        else:
+            query_list = query
+        for query_element in query_list:
+            if query_element in _json_obj:
+                _json_obj = _json_obj[query_element]
+            else:
+                raise KeyError('{} does not exist in json object'.format(query_element, _json_obj))
+        if not isinstance(_json_obj, str):
+            raise ValueError('The result of the query_string must be a string to use as a url')
+        url = _json_obj
+        # replace the template in the url with the value provided
+        if url_template_values:
+            for k, v in url_template_values.items():
+                url = re.sub('{(' + k + ')(:.*)?}', v, url)
+        if join_url:
+            url += '/' + join_url
+        # Now query the url
+        json_response = self._req(method, url, **kwargs).json()
+
+        # Depaginate the call if requested
+        if all_pages is True:
+            # This depagination code will iterate over all the pages available until the pages comes back  without a
+            # next page. It stores the embedded elements in the initial query's json response
+            content = json_response
+            while 'next' in content.get('_links'):
+                content = self._req(method, content.get('_links').get('next').get('href'), **kwargs).json()
+                for key in content.get('_embedded'):
+                    json_response['_embedded'][key].extend(content.get('_embedded').get(key))
+            # Remove the pagination information as it is not relevant to the depaginated response
+            if 'page' in json_response: json_response.pop('page')
+            if 'first' in json_response['_links']: json_response['_links'].pop('first')
+            if 'last' in json_response['_links']: json_response['_links'].pop('last')
+            if 'next' in json_response['_links']: json_response['_links'].pop('next')
+        return json_response
+
+    def follows_link(self, key, json_obj=None, method='GET', url_template_values=None, join_url=None, **kwargs):
+        """
+        Same function as follows but construct the query_string from a single keyword surrounded by '_links' and 'href'.
+        """
+        return self.follows(('_links', key, 'href'),
+                            json_obj=json_obj, method=method, url_template_values=url_template_values,
+                            join_url=join_url, **kwargs)
+
+    @cached_property
+    def root(self):
+        return self._req('GET', self.bsd_url).json()
+
+    @property
+    def communicator_attributes(self):
+        raise NotImplementedError
+
+
+class AAPHALCommunicator(HALCommunicator):
+
+    def __init__(self, auth_url, bsd_url, username, password, domain=None):
+        super(AAPHALCommunicator, self).__init__(auth_url, bsd_url, username, password)
+        self.domain = domain
+
+    @property
+    def communicator_attributes(self):
+        return {'domain': self.domain}
+
+
+class WebinHALCommunicator(HALCommunicator):
+
+    @cached_property
+    def token(self):
+        """Retrieve the token from the ENA Webin REST API then cache it for further quering"""
+        response = requests.post(self.auth_url,
+                                 json={"authRealms": ["ENA"], "password": self.password,
+                                       "username": self.username})
+        self._validate_response(response)
+        return response.text
+
+    @property
+    def communicator_attributes(self):
+        return {'webinSubmissionAccountId': self.username}

--- a/eva_submission/biosample_submission/biosamples_submitters.py
+++ b/eva_submission/biosample_submission/biosamples_submitters.py
@@ -20,6 +20,7 @@ from functools import lru_cache
 from ebi_eva_common_pyutils.config import cfg
 from ebi_eva_common_pyutils.logger import AppLogger
 
+from eva_submission.biosample_submission.biosamples_communicators import AAPHALCommunicator, WebinHALCommunicator
 from eva_submission.xlsx.xlsx_parser_eva import EvaXlsxReader
 
 _now = datetime.now().isoformat()

--- a/eva_submission/biosamples_submission.py
+++ b/eva_submission/biosamples_submission.py
@@ -14,11 +14,9 @@
 # limitations under the License.
 
 import re
-import sys
 from copy import deepcopy
 from datetime import datetime, date
 from functools import lru_cache
-from pprint import pprint
 
 import requests
 from cached_property import cached_property

--- a/eva_submission/biosamples_submission.py
+++ b/eva_submission/biosamples_submission.py
@@ -245,10 +245,11 @@ class BSDSubmitter(AppLogger):
             elif self.should_update(sample):
                 self.debug('Update sample ' + sample.get('name') + ' with accession ' + sample.get('accession'))
                 curation_object = self.convert_sample_data_to_curation_object(sample)
-                sample_json = self.communicator.follows_link('samples', method='POST',
-                                                             join_url=sample.get('accession')+'/curationlinks',
-                                                             json=curation_object)
-
+                curation_json = self.communicator.follows_link('samples', method='POST',
+                                                               join_url=sample.get('accession')+'/curationlinks',
+                                                               json=curation_object)
+                self.debug(f'Curation: {curation_json}')
+                sample_json = sample
             # Otherwise Keep the sample as is and retrieve the name so that list of sample to accession is complete
             else:
                 sample_json = self.communicator.follows_link('samples', method='GET', join_url=sample.get('accession'))

--- a/eva_submission/eload_brokering.py
+++ b/eva_submission/eload_brokering.py
@@ -10,7 +10,7 @@ from ebi_eva_common_pyutils.config import cfg
 
 from eva_submission import NEXTFLOW_DIR
 from eva_submission.ENA_submission.upload_to_ENA import ENAUploader, ENAUploaderAsync
-from eva_submission.biosamples_submission import SampleMetadataSubmitter, SampleReferenceSubmitter
+from eva_submission.biosample_submission.biosamples_submitters import SampleMetadataSubmitter, SampleReferenceSubmitter
 from eva_submission.eload_submission import Eload
 from eva_submission.eload_utils import read_md5
 from eva_submission.submission_config import EloadConfig

--- a/eva_submission/eload_brokering.py
+++ b/eva_submission/eload_brokering.py
@@ -99,7 +99,7 @@ class EloadBrokering(Eload):
     def upload_to_bioSamples(self, force=False):
         metadata_spreadsheet = self.eload_cfg['validation']['valid']['metadata_spreadsheet']
         sample_metadata_submitter = SampleMetadataSubmitter(metadata_spreadsheet)
-        if sample_metadata_submitter.check_submit_done() and not force:
+        if sample_metadata_submitter.check_submit_done():
             self.info('Biosamples accession already provided in the metadata, Skip!')
             self.eload_cfg.set('brokering', 'Biosamples', 'pass', value=True)
             # Retrieve the sample names to accession from the metadata
@@ -108,7 +108,6 @@ class EloadBrokering(Eload):
         elif (
             self.eload_cfg.query('brokering', 'Biosamples', 'Samples')
             and self.eload_cfg.query('brokering', 'Biosamples', 'pass')
-            and not force
         ):
             self.info('BioSamples brokering is already done, Skip!')
         else:

--- a/eva_submission/xlsx/xlsx_validation.py
+++ b/eva_submission/xlsx/xlsx_validation.py
@@ -10,7 +10,7 @@ from ebi_eva_common_pyutils.taxonomy.taxonomy import get_scientific_name_from_en
 from requests import HTTPError
 
 from eva_submission import ETC_DIR
-from eva_submission.biosample_submission.biosamples_submitters import AAPHALCommunicator
+from eva_submission.biosample_submission.biosamples_communicators import AAPHALCommunicator
 from eva_submission.eload_utils import cast_list, check_existing_project_in_ena, check_project_format
 from eva_submission.xlsx.xlsx_parser_eva import EvaXlsxReader, EvaXlsxWriter
 

--- a/eva_submission/xlsx/xlsx_validation.py
+++ b/eva_submission/xlsx/xlsx_validation.py
@@ -137,7 +137,8 @@ class EvaXlsxValidator(AppLogger):
             if row.get('Sample Accession'):
                 sample_accession = row.get('Sample Accession').strip()
                 try:
-                    _ = self.communicator.follows_link('samples', join_url=sample_accession)
+                    sample_data = self.communicator.follows_link('samples', join_url=sample_accession)
+                    self._validate_existing_bioSample(sample_data)
                 except ValueError:
                     self.error_list.append(
                         f'In Sample, row {row.get("row_num")} BioSamples accession {sample_accession} '
@@ -198,16 +199,17 @@ class EvaXlsxValidator(AppLogger):
                 errors.append('%s present in %s not in %s' % (','.join(list2_list1), list2_desc, list1_desc))
             self.error_list.append('Check %s vs %s: %s' % (list1_desc, list2_desc, ' -- '.join(errors)))
 
+    def _check_date(self, date):
+        return isinstance(date, datetime.date) or \
+               isinstance(date, datetime.datetime) or \
+               self._check_date_str_format(date) or \
+               str(date).lower() in not_provided_check_list
+
     def check_date(self, row, key, required=True):
         if required and key not in row:
             self.error_list.append(f'In row {row.get("row_num")}, {key} is required and missing')
             return
-        if key in row and (
-                isinstance(row[key], datetime.date) or
-                isinstance(row[key], datetime.datetime) or
-                self._check_date_str_format(row[key]) or
-                str(row[key]).lower() in not_provided_check_list
-        ):
+        if key in row and self._check_date(row[key]):
             return
         self.error_list.append(f'In row {row.get("row_num")}, {key} is not a date or "not provided": '
                                f'it is set to "{row.get(key)}"')
@@ -218,3 +220,22 @@ class EvaXlsxValidator(AppLogger):
             return True
         except ValueError:
             return False
+
+    def _validate_existing_biosample(self, sample_data, row_num, accession):
+        """This function only check if the existing sample has the expected fields present"""
+        found_collection_date=False
+        for key in  ['collection_date', 'collection date']:
+            if key in sample_data['characteristics'] and \
+                    self._check_date(sample_data['characteristics'][key][0]['text']):
+                found_collection_date = True
+        if not found_collection_date:
+            self.error_list.append(
+                f'In row {row_num}, samples accession {accession} does not have a valid collection date')
+        found_geo_loc = False
+        for key in ['geographic location (country and/or sea)']:
+            if key in sample_data['characteristics'] and \
+                    self._check_date(sample_data['characteristics'][key][0]['text']):
+                found_geo_loc = True
+        if not found_geo_loc:
+            self.error_list.append(
+                f'In row {row_num}, samples accession {accession} does not have a valid geographic location')

--- a/eva_submission/xlsx/xlsx_validation.py
+++ b/eva_submission/xlsx/xlsx_validation.py
@@ -10,7 +10,7 @@ from ebi_eva_common_pyutils.taxonomy.taxonomy import get_scientific_name_from_en
 from requests import HTTPError
 
 from eva_submission import ETC_DIR
-from eva_submission.biosamples_submission import AAPHALCommunicator
+from eva_submission.biosample_submission.biosamples_submitters import AAPHALCommunicator
 from eva_submission.eload_utils import cast_list, check_existing_project_in_ena, check_project_format
 from eva_submission.xlsx.xlsx_parser_eva import EvaXlsxReader, EvaXlsxWriter
 
@@ -138,7 +138,7 @@ class EvaXlsxValidator(AppLogger):
                 sample_accession = row.get('Sample Accession').strip()
                 try:
                     sample_data = self.communicator.follows_link('samples', join_url=sample_accession)
-                    self._validate_existing_bioSample(sample_data)
+                    self._validate_existing_bioSample(sample_data, row.get('row_num'), sample_accession)
                 except ValueError:
                     self.error_list.append(
                         f'In Sample, row {row.get("row_num")} BioSamples accession {sample_accession} '

--- a/tests/test_biosamples_submission.py
+++ b/tests/test_biosamples_submission.py
@@ -7,8 +7,10 @@ import yaml
 
 from eva_submission import ROOT_DIR
 from eva_submission.biosample_submission import biosamples_submitters
-from eva_submission.biosample_submission.biosamples_submitters import HALCommunicator, BioSamplesSubmitter, SampleMetadataSubmitter, \
-    SampleReferenceSubmitter, AAPHALCommunicator, WebinHALCommunicator
+from eva_submission.biosample_submission.biosamples_communicators import HALCommunicator, WebinHALCommunicator, \
+    AAPHALCommunicator
+from eva_submission.biosample_submission.biosamples_submitters import BioSamplesSubmitter, SampleMetadataSubmitter, \
+    SampleReferenceSubmitter
 
 
 class BSDTestCase(TestCase):
@@ -320,7 +322,7 @@ class TestSampleMetadataSubmitter(BSDTestCase):
 
     def test_map_metadata_to_bsd_data(self):
         now = '2020-07-06T19:09:29.090Z'
-        biosamples_submission._now = now
+        biosamples_submitters._now = now
         expected_payload = [
             {'name': 'S%s' % (i + 1), 'taxId': 9606, 'release': now,
              'contact': [{'LastName': 'John', 'FirstName': 'Doe', 'E-mail': 'john.doe@example.com'},

--- a/tests/test_biosamples_submission.py
+++ b/tests/test_biosamples_submission.py
@@ -3,11 +3,11 @@ from copy import deepcopy
 from unittest import TestCase
 from unittest.mock import patch, Mock, PropertyMock
 
-import pytest
 import yaml
 
-from eva_submission import biosamples_submission, ROOT_DIR
-from eva_submission.biosamples_submission import HALCommunicator, BioSamplesSubmitter, SampleMetadataSubmitter, \
+from eva_submission import ROOT_DIR
+from eva_submission.biosample_submission import biosamples_submitters
+from eva_submission.biosample_submission.biosamples_submitters import HALCommunicator, BioSamplesSubmitter, SampleMetadataSubmitter, \
     SampleReferenceSubmitter, AAPHALCommunicator, WebinHALCommunicator
 
 

--- a/tests/test_biosamples_submission.py
+++ b/tests/test_biosamples_submission.py
@@ -11,7 +11,7 @@ from eva_submission.biosample_submission.biosamples_communicators import HALComm
     AAPHALCommunicator
 from eva_submission.biosample_submission.biosamples_submitters import BioSamplesSubmitter, SampleMetadataSubmitter, \
     SampleReferenceSubmitter
-
+import eva_submission.biosample_submission.biosamples_submitters
 
 class BSDTestCase(TestCase):
 
@@ -348,7 +348,7 @@ class TestSampleMetadataSubmitter(BSDTestCase):
 
     def test_map_partial_metadata_to_bsd_data(self):
         now = '2020-07-06T19:09:29.090Z'
-        biosamples_submission._now = now
+        biosamples_submitters._now = now
         contacts = [
             {'LastName': 'John', 'FirstName': 'Doe', 'E-mail': 'john.doe@example.com'},
             {'LastName': 'Jane', 'FirstName': 'Doe', 'E-mail': 'jane.doe@example.com'}

--- a/tests/test_eload_brokering.py
+++ b/tests/test_eload_brokering.py
@@ -1,4 +1,3 @@
-import csv
 import glob
 import os
 import shutil
@@ -8,7 +7,7 @@ from unittest.mock import patch, PropertyMock
 from ebi_eva_common_pyutils.config import cfg
 
 from eva_submission import NEXTFLOW_DIR
-from eva_submission.biosamples_submission import SampleMetadataSubmitter
+from eva_submission.biosample_submission.biosamples_submitters import SampleMetadataSubmitter
 from eva_submission.eload_brokering import EloadBrokering
 from eva_submission.eload_submission import Eload
 from eva_submission.submission_config import load_config

--- a/tests/test_eload_validation.py
+++ b/tests/test_eload_validation.py
@@ -2,7 +2,6 @@ import os
 from copy import deepcopy
 from unittest import TestCase
 from unittest.mock import patch
-import yaml
 
 from eva_vcf_merge.detect import MergeType
 from eva_vcf_merge.merge import VCFMerger


### PR DESCRIPTION
This PR change the process for BioSample creation and update.
The `biosample_submission.py` can now create a new BioSample, overwrite and existing one, add a curation object on top of an existing one, or create a derived sample from an existing one.

The brokering only allows to Create new BioSample or use existing one as is
A new script should be used to update existing Biosamples
Validation identify existing BioSample missing collection date or geographic location.