### PR TITLE
EVA-3308 - extract VCF file with taxonomy id

### DIFF
--- a/eva_submission/nextflow/remap_and_cluster.nf
+++ b/eva_submission/nextflow/remap_and_cluster.nf
@@ -127,7 +127,7 @@ process extract_vcf_from_mongo {
 
     output:
     // Only pass on the EVA vcf, dbSNP one will be empty
-    tuple val(source_assembly_accession), path(source_fasta), path("${source_assembly_accession}_eva.vcf"), emit: source_vcfs
+    tuple val(source_assembly_accession), path(source_fasta), path("${source_assembly_accession}*_eva.vcf"), emit: source_vcfs
     path "${source_assembly_accession}_vcf_extractor.log", emit: log_filename
 
     publishDir "$params.logs_dir", overwrite: true, mode: "copy", pattern: "*.log*"


### PR DESCRIPTION
Retrieve the VCF file with the taxonomy id included. 
This should be backward compatible