### PR TITLE
Fix from production

### DIFF
--- a/eva_submission/biosample_submission/biosamples_submitters.py
+++ b/eva_submission/biosample_submission/biosamples_submitters.py
@@ -70,6 +70,9 @@ class BioSamplesSubmitter(AppLogger):
 
     def validate_in_bsd(self, samples_data):
         for sample in samples_data:
+            if self.can_overwrite(sample):
+                sample = self.create_sample_to_overwrite(sample)
+
             # If we're only retrieving don't need to validate.
             if self.can_create(sample) or self.can_overwrite(sample):
                 sample.update(self.default_communicator.communicator_attributes)
@@ -441,7 +444,8 @@ class SampleMetadataSubmitter(SampleSubmitter):
             ])
 
     def all_sample_names(self):
-        return [s.get('name') for s in self.sample_data]
+        # We need to get back to the reader to get all the names that were present in the spreadsheet
+        return [sample_row.get('Sample Name') or sample_row.get('Sample ID') for sample_row in self.reader.samples]
 
 
 class SampleReferenceSubmitter(SampleSubmitter):

--- a/eva_submission/submission_qc_checks.py
+++ b/eva_submission/submission_qc_checks.py
@@ -285,10 +285,11 @@ class EloadQC(Eload):
             analysis_to_file_names[analysis_accession] = [
                 os.path.basename(f) for f in self.analyses.get(analysis_alias).get('vcf_files')
             ]
-
-            self._find_log_and_check_job(
-                analysis_accession, f"annotation.*{analysis_accession}*.log", "annotate_variants", failed_analysis
-            )
+            assembly_accession = self.eload_cfg.query('brokering', 'analyses', analysis_alias, 'assembly_accession')
+            if self.eload_cfg.query('ingestion', 'vep', assembly_accession, 'cache_version', ret_default=None) == None:
+                self._find_log_and_check_job(
+                    analysis_accession, f"annotation.*{analysis_accession}*.log", "annotate_variants", failed_analysis
+                )
             # Statistics is only run if the aggregation is set to none
             if self.eload_cfg.query('ingestion', 'aggregation', analysis_accession, ret_default='none') == 'none':
                 self._find_log_and_check_job(

--- a/eva_submission/submission_qc_checks.py
+++ b/eva_submission/submission_qc_checks.py
@@ -285,8 +285,9 @@ class EloadQC(Eload):
             analysis_to_file_names[analysis_accession] = [
                 os.path.basename(f) for f in self.analyses.get(analysis_alias).get('vcf_files')
             ]
+            # annotation only happens if a VEP cache can be found
             assembly_accession = self.eload_cfg.query('brokering', 'analyses', analysis_alias, 'assembly_accession')
-            if self.eload_cfg.query('ingestion', 'vep', assembly_accession, 'cache_version', ret_default=None) == None:
+            if self.eload_cfg.query('ingestion', 'vep', assembly_accession, 'cache_version') == None:
                 self._find_log_and_check_job(
                     analysis_accession, f"annotation.*{analysis_accession}*.log", "annotate_variants", failed_analysis
                 )


### PR DESCRIPTION
To get the sample names, use the spreadsheet to get both the existing and novel names
Fix qc submission to avoid checking VEP run when no run was performed
