### PR TITLE
EVA-3604 - Add naming convention check

### DIFF
--- a/eva_submission/eload_submission.py
+++ b/eva_submission/eload_submission.py
@@ -25,6 +25,7 @@ directory_structure = {
     'sample_check': '13_validation/sample_concordance',
     'normalisation_check': '13_validation/normalisation',
     'sv_check': '13_validation/structural_variant',
+    'naming_convention_check': '13_validation/naming_convention',
     'merge': '14_merge',
     'biosamples': '18_brokering/biosamples',
     'ena': '18_brokering/ena',

--- a/eva_submission/nextflow/validation.nf
+++ b/eva_submission/nextflow/validation.nf
@@ -39,7 +39,7 @@ workflow {
         .map{row -> tuple(file(row.vcf), file(row.fasta), file(row.report))}
     vcf_info_acc_ch = Channel.fromPath(params.vcf_files_mapping)
         .splitCsv(header:true)
-        .map{row -> tuple(file(row.vcf), val(row.assembly_accession)}
+        .map{row -> tuple(file(row.vcf), val(row.assembly_accession))}
 
     if ("vcf_check" in params.validation_tasks) {
         check_vcf_valid(vcf_info_ch)

--- a/eva_submission/nextflow/validation.nf
+++ b/eva_submission/nextflow/validation.nf
@@ -155,7 +155,7 @@ process detect_naming_convention {
             mode: "copy"
 
     input:
-    tuple path(vcf_file), path(accession)
+    tuple path(vcf_file), val(accession)
 
     output:
     path "naming_convention_check/*_naming_convention.yml", emit: nc_check_yml

--- a/eva_submission/nextflow/validation.nf
+++ b/eva_submission/nextflow/validation.nf
@@ -39,7 +39,7 @@ workflow {
         .map{row -> tuple(file(row.vcf), file(row.fasta), file(row.report))}
     vcf_info_acc_ch = Channel.fromPath(params.vcf_files_mapping)
         .splitCsv(header:true)
-        .map{row -> tuple(file(row.vcf), val(row.assembly_accession))}
+        .map{row -> tuple(file(row.vcf), row.assembly_accession)}
 
     if ("vcf_check" in params.validation_tasks) {
         check_vcf_valid(vcf_info_ch)
@@ -155,7 +155,7 @@ process detect_naming_convention {
             mode: "copy"
 
     input:
-    tuple path(vcf_file), val(accession)
+    tuple path(vcf_file), accession
 
     output:
     path "naming_convention_check/*_naming_convention.yml", emit: nc_check_yml

--- a/eva_submission/steps/detect_contigs_naming_convention.py
+++ b/eva_submission/steps/detect_contigs_naming_convention.py
@@ -71,7 +71,7 @@ class ContigsNamimgConventionChecker(AppLogger):
         self.contig_alias = ContigAliasClient()
 
     def naming_convention_map_for_vcf(self, input_vcf):
-        """Provides a set of contigs names present in the VCF file"""
+        """Provides a set of contigs names present in the VCF file for each compatible naming convention"""
         naming_convention_map = defaultdict(list)
         if input_vcf.endswith('.gz'):
             vcf_in = gzip.open(input_vcf, mode="rt")
@@ -91,13 +91,13 @@ class ContigsNamimgConventionChecker(AppLogger):
         """
         contig_conventions_map_tmp = defaultdict(list)
         for entity in self.contig_alias.assembly(self.assembly_accession):
-            for naming_convention in ['insdcAccession', 'refseq', 'enaSequenceName', 'genbankSequenceName', 'ucscName']:
+            for naming_convention in naming_convention_priority.keys():
                 if naming_convention in entity and entity[naming_convention]:
                     contig_conventions_map_tmp[entity[naming_convention]].append(naming_convention)
         return contig_conventions_map_tmp
 
     def get_contig_convention(self, contig_name):
-        naming_connventions = self._contig_conventions_map.get(contig_name)
+        naming_conventions = self._contig_conventions_map.get(contig_name)
         if not naming_connventions:
             return 'Not found'
         # prioritise naming conventions and take the highest priority one

--- a/eva_submission/steps/detect_contigs_naming_convention.py
+++ b/eva_submission/steps/detect_contigs_naming_convention.py
@@ -16,11 +16,10 @@ import os.path
 from argparse import ArgumentParser
 from collections import defaultdict
 
-import requests
 import yaml
 from cached_property import cached_property
+from ebi_eva_common_pyutils.contig_alias.contig_alias import ContigAliasClient
 from ebi_eva_common_pyutils.logger import AppLogger
-from retry import retry
 
 # Order in which the naming convention will be kept if multiple are equivalent
 naming_convention_priority = {
@@ -31,36 +30,6 @@ naming_convention_priority = {
     'refseq': 5
 }
 
-
-class ContigAliasClient:
-
-    CONTING_ALIAS_URL = 'https://www.ebi.ac.uk/eva/webservices/contig-alias'
-
-    def __init__(self, contig_alias_url=CONTING_ALIAS_URL, default_page_size=1000):
-        self.contig_alias_url=contig_alias_url
-        self.default_page_size=default_page_size
-
-    @retry(tries=3, delay=2, backoff=1.2, jitter=(1, 3))
-    def _get_contig_alias_assembly(self, assembly_accession, page=0):
-        """queries the contig alias to retrieve the list of chromosome associated with the assembly for one page"""
-        url = (f'{self.contig_alias_url}/v1/assemblies/{assembly_accession}/'
-               f'chromosomes?page={page}&size={self.default_page_size}')
-        response = requests.get(url, headers={'accept': 'application/json'})
-        response.raise_for_status()
-        response_json = response.json()
-        return response_json
-
-    def assembly(self, assembly_accession):
-        """Generator that provides the contigs in the assembly requested."""
-        page = 0
-        response_json = self._get_contig_alias_assembly(assembly_accession, page=page)
-        for entity in response_json.get('_embedded', {}).get('chromosomeEntities', []):
-            yield entity
-        while 'next' in response_json['_links']:
-            page += 1
-            response_json = self._get_contig_alias_assembly(assembly_accession, page=page)
-            for entity in response_json.get('_embedded', {}).get('chromosomeEntities', []):
-                yield entity
 
 class ContigsNamimgConventionChecker(AppLogger):
     """
@@ -90,7 +59,7 @@ class ContigsNamimgConventionChecker(AppLogger):
         Dictionary of contig names to naming convention based on the contig alias.
         """
         contig_conventions_map_tmp = defaultdict(list)
-        for entity in self.contig_alias.assembly(self.assembly_accession):
+        for entity in self.contig_alias.assembly_contig_iter(self.assembly_accession):
             for naming_convention in naming_convention_priority.keys():
                 if naming_convention in entity and entity[naming_convention]:
                     contig_conventions_map_tmp[entity[naming_convention]].append(naming_convention)
@@ -98,17 +67,17 @@ class ContigsNamimgConventionChecker(AppLogger):
 
     def get_contig_convention(self, contig_name):
         naming_conventions = self._contig_conventions_map.get(contig_name)
-        if not naming_connventions:
+        if not naming_conventions:
             return 'Not found'
         # prioritise naming conventions and take the highest priority one
-        return sorted(naming_connventions, key=lambda nc: naming_convention_priority.get(nc))[0]
+        return sorted(naming_conventions, key=lambda nc: naming_convention_priority.get(nc))[0]
 
     def write_convention_map_to_yaml(self, vcf_files, output_yaml):
         results = []
         for input_vcf in vcf_files:
             naming_convention_to_contigs = self.naming_convention_map_for_vcf(input_vcf)
             if len(naming_convention_to_contigs) == 1:
-                naming_convention = naming_convention_to_contigs.keys()[0]
+                naming_convention = list(naming_convention_to_contigs)[0]
                 naming_convention_map = None
             else:
                 naming_convention = None

--- a/eva_submission/steps/detect_contigs_naming_convention.py
+++ b/eva_submission/steps/detect_contigs_naming_convention.py
@@ -1,0 +1,122 @@
+# Copyright 2022 EMBL - European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import gzip
+from argparse import ArgumentParser
+from collections import defaultdict
+from csv import DictReader, excel_tab
+
+import requests
+from cached_property import cached_property
+from ebi_eva_common_pyutils.logger import AppLogger
+from retry import retry
+
+
+class ContigsNamimgConventionChecker(AppLogger):
+    """
+    This check names of contigs in VCF and report back the naming convention
+    """
+    def __init__(self, assembly_accession):
+        self.assembly_accession = assembly_accession
+
+    def naming_convention_map_for_vcf(self, input_vcf):
+        """Provides a set of contigs names present in the VCF file"""
+        naming_conventions = defaultdict(list)
+        contigs = set
+        if input_vcf.endswith('.gz'):
+            vcf_in = gzip.open(input_vcf, mode="rt")
+        else:
+            vcf_in = open(input_vcf, mode="r")
+        for line in vcf_in:
+            if line.startswith("#"):
+                continue
+            contigs.add(line.split('\t')[0])
+        for contig in contigs:
+            naming_conventions[self.contig_convention_map[contig]].append(contig)
+        return naming_conventions
+
+    @retry(tries=3, delay=2, backoff=1.2, jitter=(1, 3))
+    def _contig_alias_assembly_get(self, page=0, size=10):
+        """queries the contig alias to retrieve the list of chromosome associated with the assembly for one page"""
+        url = (f'https://www.ebi.ac.uk/eva/webservices/contig-alias/v1/assemblies/{self.assembly_accession}/'
+               f'chromosomes?page={page}&size={size}')
+        response = requests.get(url, headers={'accept': 'application/json'})
+        response.raise_for_status()
+        response_json = response.json()
+        return response_json
+
+    @staticmethod
+    def _add_chromosomes_convention_to_map(assembly_data, contig_convention_map_tmp):
+        """Add non-INSDC to INSDC accession mapping based on the contig alias response."""
+        for entity in assembly_data.get('chromosomeEntities', []):
+            for naming_convention in ['insdcAccession', 'refseq', 'enaSequenceName', 'genbankSequenceName', 'ucscName']:
+                if naming_convention in entity and entity[naming_convention]:
+                    contig_convention_map_tmp[entity[naming_convention]].append(naming_convention)
+
+    @cached_property
+    def contig_convention_map(self):
+        """
+        Dictionary of contig names to naming convention based on the contig alias.
+        """
+        contig_convention_map_tmp = defaultdict(list)
+        page = 0
+        size = 1000
+        response_json = self._contig_alias_assembly_get(page=page, size=size)
+        self._add_chromosomes_convention_to_map(response_json.get('_embedded', {}), contig_convention_map_tmp)
+        while 'next' in response_json['_links']:
+            page += 1
+            response_json = self._contig_alias_assembly_get(page=page, size=size)
+            self._add_chromosomes_convention_to_map(response_json.get('_embedded', {}), contig_convention_map_tmp)
+        return contig_convention_map_tmp
+
+    def rewrite_changing_names(self, output_fasta):
+        """Create a new fasta file with contig names use in the VCF."""
+        with open(self.assembly_fasta_path) as open_input, open(output_fasta, 'w') as open_output:
+            for line in open_input:
+                if line.startswith('>'):
+                    contig_name = line.split()[0][1:]
+                    assembly_report_name = self.assembly_report_map.get(contig_name)
+                    contig_alias_name = self.contig_alias_map.get(contig_name)
+                    if assembly_report_name:
+                        contig_name = assembly_report_name
+                    elif contig_alias_name:
+                        contig_name = contig_alias_name
+                    line = '>' + contig_name + '\n'
+                open_output.write(line)
+
+
+def main():
+    argparse = ArgumentParser(description='Convert a genome file from INSDC accession to the naming convention '
+                                          'used in the VCFs')
+    argparse.add_argument('--assembly_accession', required=True, type=str,
+                          help='The assembly accession of this genome')
+    argparse.add_argument('--assembly_fasta', required=True, type=str,
+                          help='The path to the fasta file containing the genome sequences')
+    argparse.add_argument('--custom_fasta', required=True, type=str,
+                          help='The path to the fasta file containing the renamed sequences')
+    argparse.add_argument('--assembly_report', required=True, type=str,
+                          help='The path to the file containing the assembly report')
+    argparse.add_argument('--vcf_files', required=True, type=str, nargs='+',
+                          help='Path to one or several VCF files')
+
+    args = argparse.parse_args()
+    naming_convention = ContigsNamimgConventionChecker(assembly_accession=args.assembly_accession)
+    for input_vcf in args.vcf_files:
+        naming_convention_map, contigs = naming_convention.naming_convention_map_for_vcf(input_vcf)
+
+    input_vcfs = args.vcf_files
+        .rewrite_changing_names(args.custom_fasta)
+
+
+if __name__ == "__main__":
+    main()

--- a/eva_submission/steps/detect_contigs_naming_convention.py
+++ b/eva_submission/steps/detect_contigs_naming_convention.py
@@ -93,8 +93,7 @@ class ContigsNamimgConventionChecker(AppLogger):
 
 
 def main():
-    argparse = ArgumentParser(description='Convert a genome file from INSDC accession to the naming convention '
-                                          'used in the VCFs')
+    argparse = ArgumentParser(description='Detect the naming convention used in the VCF files provided.')
     argparse.add_argument('--assembly_accession', required=True, type=str,
                           help='The assembly accession of this genome')
     argparse.add_argument('--vcf_files', required=True, type=str, nargs='+',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cached-property
 cerberus
-ebi-eva-common-pyutils[eva-internal]==0.6.8
+ebi-eva-common-pyutils[eva-internal]==0.6.9
 eva-vcf-merge==0.0.8
 humanize
 lxml

--- a/tests/resources/eloads/ELOAD_2/.ELOAD_2_config.yml
+++ b/tests/resources/eloads/ELOAD_2/.ELOAD_2_config.yml
@@ -59,3 +59,11 @@ validation:
         normalisation_log: /path/to/report
         normalised_vcf: normalised_test.vcf.gz
     pass: true
+  naming_convention_check:
+    pass: true
+    naming_convention: enaSequenceName
+    files:
+      - {
+          vcf_file: test.vcf,
+          naming_convention: enaSequenceName
+      }

--- a/tests/test_detect_naming_conventions.py
+++ b/tests/test_detect_naming_conventions.py
@@ -1,0 +1,56 @@
+import os
+from unittest import TestCase
+
+import yaml
+
+from eva_submission.steps.detect_contigs_naming_convention import ContigsNamimgConventionChecker
+
+
+class TestContigsNamimgConventionChecker(TestCase):
+    resources = os.path.join(os.path.dirname(__file__), 'resources')
+
+    def setUp(self) -> None:
+        self.assembly_accession = 'GCA_000002945.2'
+        self.input_vcf = os.path.join(self.resources, 'vcf_files', 'vcf_file_ASM294v2.vcf')
+        self.output_yaml = os.path.join(self.resources, 'output_ASM294v2.yaml')
+        self.checker = ContigsNamimgConventionChecker(self.assembly_accession)
+
+    def tearDown(self) -> None:
+        if os.path.exists(self.output_yaml):
+            os.remove(self.output_yaml)
+
+    def test_contig_conventions_map(self):
+        expected_map = {
+            'CU329670.1': ['insdcAccession'],
+            'NC_003424.3': ['refseq'],
+            'I': ['enaSequenceName', 'genbankSequenceName'],
+            'CU329671.1': ['insdcAccession'],
+            'NC_003423.3': ['refseq'],
+            'II': ['enaSequenceName', 'genbankSequenceName'],
+            'CU329672.1': ['insdcAccession'],
+            'NC_003421.2': ['refseq'],
+            'III': ['enaSequenceName', 'genbankSequenceName'],
+            'X54421.1': ['insdcAccession'],
+            'NC_001326.1': ['refseq'],
+            'MT': ['enaSequenceName', 'genbankSequenceName']
+        }
+        all_contigs = dict(self.checker._contig_conventions_map)
+        assert all_contigs == expected_map
+
+    def test_get_contig_convention(self):
+        assert self.checker.get_contig_convention('MT') == 'enaSequenceName'
+
+    def test_naming_convention_map_for_vcf(self):
+        expected_convention = {'enaSequenceName': ['I', 'II', 'III', 'MT'], 'Not found': ['MTR']}
+        convention_map = self.checker.naming_convention_map_for_vcf(self.input_vcf)
+        assert convention_map == expected_convention
+
+    def test_write_convention_map_to_yaml(self):
+        expected_list = [{'assembly_accession': 'GCA_000002945.2', 'naming_convention': None,
+         'naming_convention_map': {'Not found': ['MTR'], 'enaSequenceName': ['I', 'II', 'III', 'MT']},
+         'vcf_file': os.path.basename(self.input_vcf)}]
+        self.checker.write_convention_map_to_yaml([self.input_vcf], self.output_yaml)
+        with open(self.output_yaml) as open_yaml:
+            data = yaml.safe_load(open_yaml)
+            print(data)
+            assert data == expected_list

--- a/tests/test_eload_validation.py
+++ b/tests/test_eload_validation.py
@@ -91,6 +91,7 @@ Assembly check: PASS
 Sample names check: PASS
 Aggregation check: PASS
 Structural variant check: PASS
+Naming convention check: PASS
 ----------------------------------
 
 Metadata check:
@@ -140,6 +141,12 @@ VCF merge:
 
 Structural variant check:
   * test.vcf has structural variants
+
+----------------------------------
+
+Naming convention check:
+  * Naming convention: enaSequenceName
+    * test.vcf: enaSequenceName
 
 ----------------------------------
 '''


### PR DESCRIPTION
Add a new validation that always succeeds. 
It should check and retrieve the naming convention use in each VCF file and summarise it in the config