### PR TITLE
Remove maxForks restriction in accessioning

### DIFF
--- a/eva_submission/nextflow/accession_and_load.nf
+++ b/eva_submission/nextflow/accession_and_load.nf
@@ -214,8 +214,6 @@ process accession_vcf {
     clusterOptions "-o $params.logs_dir/${log_filename}.log \
                     -e $params.logs_dir/${log_filename}.err"
 
-    maxForks 1
-
     input:
     tuple val(vcf_filename), val(vcf_file), val(assembly_accession), val(aggregation), val(fasta), val(report)
 


### PR DESCRIPTION
After [EVA-3721](https://www.ebi.ac.uk/panda/jira/browse/EVA-3721) this restriction is no longer needed.