### PR TITLE
Few fixes from prod

### DIFF
--- a/eva_submission/etc/eva_project_conf.yaml
+++ b/eva_submission/etc/eva_project_conf.yaml
@@ -64,6 +64,9 @@ Analysis:
     - Date
     - Link(s)
     - Run Accession(s)
+  cast:
+    Imputation: string
+    Phasing: string
 
 Sample:
   header_row: 3

--- a/eva_submission/xlsx/xlsx_validation.py
+++ b/eva_submission/xlsx/xlsx_validation.py
@@ -8,6 +8,7 @@ from ebi_eva_common_pyutils.assembly_utils import retrieve_genbank_assembly_acce
 from ebi_eva_common_pyutils.biosamples_communicators import AAPHALCommunicator
 from ebi_eva_common_pyutils.config import cfg
 from ebi_eva_common_pyutils.logger import AppLogger
+from ebi_eva_common_pyutils.reference import NCBIAssembly
 from ebi_eva_common_pyutils.taxonomy.taxonomy import get_scientific_name_from_ensembl
 from requests import HTTPError
 
@@ -115,6 +116,9 @@ class EvaXlsxValidator(AppLogger):
         references = set([row['Reference'] for row in self.metadata['Analysis'] if row['Reference']])
         for reference in references:
             accessions = retrieve_genbank_assembly_accessions_from_ncbi(reference, api_key=cfg.get('eutils_api_key'))
+            # if the searched term is an actual genome GCA accession:
+            if NCBIAssembly.is_assembly_accession_format(reference) and reference in accessions:
+                accessions = {reference}
             if len(accessions) == 0:
                 self.error_list.append(f'In Analysis, Reference {reference} did not resolve to any accession')
             elif len(accessions) > 1:

--- a/eva_submission/xlsx/xlsx_validation.py
+++ b/eva_submission/xlsx/xlsx_validation.py
@@ -9,7 +9,7 @@ from ebi_eva_common_pyutils.biosamples_communicators import AAPHALCommunicator
 from ebi_eva_common_pyutils.config import cfg
 from ebi_eva_common_pyutils.logger import AppLogger
 from ebi_eva_common_pyutils.reference import NCBIAssembly
-from ebi_eva_common_pyutils.taxonomy.taxonomy import get_scientific_name_from_ensembl, get_scientific_name_from_taxonomy
+from ebi_eva_common_pyutils.taxonomy.taxonomy import get_scientific_name_from_taxonomy
 from requests import HTTPError
 
 from eva_submission import ETC_DIR
@@ -136,7 +136,7 @@ class EvaXlsxValidator(AppLogger):
                         correct_taxid_sc_name[taxid] = scientific_name
                     else:
                         self.error_list.append(
-                            f'In Samples, Taxonomy {taxid} and scientific name {species} are inconsistent')
+                            f'In Samples, Taxonomy {taxid} ({scientific_name}) and scientific name {species} are inconsistent')
             except ValueError as e:
                 self.error(str(e))
                 self.error_list.append(str(e))

--- a/eva_submission/xlsx/xlsx_validation.py
+++ b/eva_submission/xlsx/xlsx_validation.py
@@ -9,7 +9,7 @@ from ebi_eva_common_pyutils.biosamples_communicators import AAPHALCommunicator
 from ebi_eva_common_pyutils.config import cfg
 from ebi_eva_common_pyutils.logger import AppLogger
 from ebi_eva_common_pyutils.reference import NCBIAssembly
-from ebi_eva_common_pyutils.taxonomy.taxonomy import get_scientific_name_from_ensembl
+from ebi_eva_common_pyutils.taxonomy.taxonomy import get_scientific_name_from_ensembl, get_scientific_name_from_taxonomy
 from requests import HTTPError
 
 from eva_submission import ETC_DIR
@@ -130,7 +130,7 @@ class EvaXlsxValidator(AppLogger):
         taxid_and_species_list = set([(row['Tax Id'], row['Scientific Name']) for row in self.metadata['Sample'] if row['Tax Id']])
         for taxid, species in taxid_and_species_list:
             try:
-                scientific_name = get_scientific_name_from_ensembl(int(taxid))
+                scientific_name = get_scientific_name_from_taxonomy(int(taxid))
                 if species != scientific_name:
                     if species.lower() == scientific_name.lower():
                         correct_taxid_sc_name[taxid] = scientific_name

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cached-property
 cerberus
-ebi-eva-common-pyutils[eva-internal]==0.6.12
+ebi-eva-common-pyutils[eva-internal]==0.6.15
 eva-vcf-merge==0.0.8
 humanize
 lxml

--- a/tests/test_xlsx_validation.py
+++ b/tests/test_xlsx_validation.py
@@ -57,7 +57,7 @@ class TestEvaXlsValidator(TestCase):
         self.assertEqual(self.validator_fail.error_list, expected_errors)
 
     def test_validate(self):
-        with patch('eva_submission.xlsx.xlsx_validation.get_scientific_name_from_ensembl') as m_sci_name:
+        with patch('eva_submission.xlsx.xlsx_validation.get_scientific_name_from_taxonomy') as m_sci_name:
             m_sci_name.return_value = 'Homo sapiens'
             self.validator.validate()
         assert self.validator.error_list == []
@@ -70,11 +70,11 @@ class TestEvaXlsValidator(TestCase):
         assert len([s for s in scientific_name_list if s == 'Homo Sapiens']) == 10
         assert len([s for s in scientific_name_list if s == 'HS']) == 10
 
-        with patch('eva_submission.xlsx.xlsx_validation.get_scientific_name_from_ensembl') as m_sci_name,\
+        with patch('eva_submission.xlsx.xlsx_validation.get_scientific_name_from_taxonomy') as m_sci_name,\
              patch_retrieve_genbank_assembly_accessions_from_ncbi():
             m_sci_name.return_value = 'Homo sapiens'
             self.validator_sc_name.validate()
-        assert self.validator_sc_name.error_list == ['In Samples, Taxonomy 9606 and scientific name HS are inconsistent']
+        assert self.validator_sc_name.error_list == ['In Samples, Taxonomy 9606 (Homo sapiens) and scientific name HS are inconsistent']
 
         reader_after_modification = EvaXlsxReader(self.metadata_file_wrong_sc_name_copy)
         scientific_name_list = [sample['Scientific Name'] for sample in reader_after_modification.samples]


### PR DESCRIPTION
- When searching for a GCA and it returns multiple assembly (because the search is done on text match), select the GCA that was used for the search. 
- Compare taxonomy vs scientific name using the scientific name from Ensembl or NCBI.