### PR TITLE
EVA-3694 - Run eva-sub-cli as part of validation

### DIFF
--- a/eva_sub_cli_processing/sub_cli_to_eload_converter/sub_cli_to_eload_converter.py
+++ b/eva_sub_cli_processing/sub_cli_to_eload_converter/sub_cli_to_eload_converter.py
@@ -31,5 +31,7 @@ class SubCLIToEloadConverter(EloadPreparation):
         metadata_xlsx_file_path = os.path.join(metadata_dir, "metadata_xlsx.xlsx")
         # download metadata json
         download_metadata_json_file_for_submission_id(submission_id, metadata_json_file_path)
+        # Store path to metadata json in the eload config
+        self.eload_cfg.set('submission', 'metadata_json', value=metadata_json_file_path)
         # convert metadata json to metadata xlsx
         JsonToXlsxConverter(metadata_json_file_path, metadata_xlsx_file_path).convert_json_to_xlsx()

--- a/eva_submission/eload_preparation.py
+++ b/eva_submission/eload_preparation.py
@@ -16,7 +16,7 @@ from retry import retry
 from eva_sub_cli_processing.sub_cli_to_eload_converter.json_to_xlsx_converter import JsonToXlsxConverter
 from eva_submission.eload_submission import Eload, directory_structure
 from eva_submission.eload_utils import resolve_accession_from_text, get_reference_fasta_and_report, NCBIAssembly, \
-    create_assembly_report_from_fasta
+    create_assembly_report_from_fasta, is_vcf_file
 from eva_submission.submission_in_ftp import FtpDepositBox
 from eva_submission.xlsx.xlsx_parser_eva import EvaXlsxReader, EvaXlsxWriter
 
@@ -99,7 +99,7 @@ class EloadPreparation(Eload):
         eva_xls_reader = EvaXlsxReader(eva_files_sheet)
         spreadsheet_vcfs = [
             os.path.basename(row['File Name']) for row in eva_xls_reader.files
-            if row['File Type'] == 'vcf' or row['File Name'].endswith('.vcf') or row['File Name'].endswith('.vcf.gz')
+            if is_vcf_file(row['File Name'])
         ]
 
         if sorted(spreadsheet_vcfs) != sorted(submitted_vcfs):
@@ -148,7 +148,7 @@ class EloadPreparation(Eload):
                 self.error(f"Reference is missing for Analysis {analysis.get('Analysis Alias')}")
 
         for file in eva_metadata.files:
-            if file.get("File Type") == 'vcf':
+            if is_vcf_file(file.get('File Name')):
                 file_full = os.path.join(self.eload_dir, directory_structure['vcf'], file.get("File Name"))
                 analysis_alias = self._unique_alias(file.get("Analysis Alias"))
                 analysis_reference[analysis_alias]['vcf_files'].append(file_full)

--- a/eva_submission/eload_preparation.py
+++ b/eva_submission/eload_preparation.py
@@ -208,7 +208,7 @@ class EloadPreparation(Eload):
 
         # Overwrite taxid & assembly accession values, if specified
         if taxid:
-            metadata_json['project']['taxid'] = taxid
+            metadata_json['project']['taxId'] = taxid
         if reference_accession:
             for analysis in metadata_json['analysis']:
                 analysis['referenceGenome'] = reference_accession

--- a/eva_submission/eload_preparation.py
+++ b/eva_submission/eload_preparation.py
@@ -216,9 +216,11 @@ class EloadPreparation(Eload):
         # Overwrite paths to assembly fasta and assembly report
         analyses_in_config = self.eload_cfg.query('submission', 'analyses')
         for analysis in metadata_json['analysis']:
-            if analysis.get('analysisAlias') in analyses_in_config:
-                analysis['referenceFasta'] = analyses_in_config.get(analysis['analysisAlias']).get('assembly_fasta')
-                analysis['assemblyReport'] = analyses_in_config.get(analysis['analysisAlias']).get('assembly_report')
+            unique_alias_in_json = self._unique_alias(analysis.get('analysisAlias'))
+            if unique_alias_in_json in analyses_in_config:
+                analysis['referenceFasta'] = analyses_in_config.get(unique_alias_in_json).get('assembly_fasta')
+                analysis['assemblyReport'] = analyses_in_config.get(unique_alias_in_json).get('assembly_report')
+                self.info(f'Added fasta and assembly report to json for {analysis["analysisAlias"]}')
 
         # Rewrite the metadata json file
         with open(metadata_json_path, 'w') as json_file:

--- a/eva_submission/eload_preparation.py
+++ b/eva_submission/eload_preparation.py
@@ -222,6 +222,11 @@ class EloadPreparation(Eload):
                 analysis['assemblyReport'] = analyses_in_config.get(unique_alias_in_json).get('assembly_report')
                 self.info(f'Added fasta and assembly report to json for {analysis["analysisAlias"]}')
 
+        # Overwrite file names to full paths
+        for file in metadata_json['files']:
+            file['fileName'] = os.path.join(self.eload_dir, directory_structure['vcf'], file['fileName'])
+            self.info(f'Updated {file["fileName"]} to full path')
+
         # Rewrite the metadata json file
         with open(metadata_json_path, 'w') as json_file:
             json.dump(metadata_json, json_file)
@@ -265,4 +270,3 @@ class EloadPreparation(Eload):
             except IndexError as e:
                 self.error(f'Could not convert metadata version {version} to JSON file: {metadata_xlsx}')
                 raise e
-

--- a/eva_submission/eload_submission.py
+++ b/eva_submission/eload_submission.py
@@ -27,6 +27,7 @@ directory_structure = {
     'normalisation_check': '13_validation/normalisation',
     'sv_check': '13_validation/structural_variant',
     'naming_convention_check': '13_validation/naming_convention',
+    'eva_sub_cli': '13_validation/eva_sub_cli',
     'merge': '14_merge',
     'biosamples': '18_brokering/biosamples',
     'ena': '18_brokering/ena',

--- a/eva_submission/eload_utils.py
+++ b/eva_submission/eload_utils.py
@@ -92,6 +92,10 @@ def get_file_content(file_path):
     return fc
 
 
+def is_vcf_file(file_path):
+    return file_path and (file_path.endswith('.vcf') or file_path.endswith('.vcf.gz'))
+
+
 def cast_list(l, type_to_cast=str):
     for e in l:
         yield type_to_cast(e)

--- a/eva_submission/eload_validation.py
+++ b/eva_submission/eload_validation.py
@@ -454,7 +454,7 @@ class EloadValidation(Eload):
         # Move the results to the validations folder
         results_path = resolve_single_file_path(os.path.join(output_dir, 'validation_results.yaml'))
         self._move_file(results_path, os.path.join(self._get_dir('eva_sub_cli'), 'validation_results.yaml'))
-        report_path = resolve_single_file_path(os.path.join(output_dir, 'report.html'))
+        report_path = resolve_single_file_path(os.path.join(output_dir, 'validation_output', 'report.html'))
         self._move_file(report_path, os.path.join(self._get_dir('eva_sub_cli'), 'report.html'))
 
     def _metadata_check_report(self):

--- a/eva_submission/eload_validation.py
+++ b/eva_submission/eload_validation.py
@@ -588,6 +588,8 @@ class EloadValidation(Eload):
         report_path = os.path.join(self._get_dir('eva_sub_cli'), 'report.html')
         if os.path.exists(report_path):
             return f'See {report_path}'
+        if self.eload_cfg.query('submission', 'metadata_json'):
+            return f'Process failed, check logs'
         return f'Did not run'
 
     def report(self):

--- a/eva_submission/eload_validation.py
+++ b/eva_submission/eload_validation.py
@@ -21,7 +21,7 @@ from eva_submission.xlsx.xlsx_validation import EvaXlsxValidator
 class EloadValidation(Eload):
 
     all_validation_tasks = ['metadata_check', 'assembly_check', 'aggregation_check', 'vcf_check', 'sample_check',
-                            'structural_variant_check', 'naming_convention_check', 'eva_sub_cli']
+                            'structural_variant_check', 'naming_convention_check']
 
     def validate(self, validation_tasks=None, set_as_valid=False, merge_per_analysis=False):
         if not validation_tasks:
@@ -40,7 +40,7 @@ class EloadValidation(Eload):
         if 'sample_check' in validation_tasks:
             self._validate_sample_names()
         if set(validation_tasks).intersection(
-                {'vcf_check', 'assembly_check', 'structural_variant_check', 'naming_convention_check', 'eva_sub_cli'}
+                {'vcf_check', 'assembly_check', 'structural_variant_check', 'naming_convention_check'}
         ):
             output_dir = self._run_validation_workflow(validation_tasks)
             self._collect_validation_workflow_results(output_dir, validation_tasks)
@@ -307,8 +307,8 @@ class EloadValidation(Eload):
             self._collect_structural_variant_check_results(vcf_files, output_dir)
         if 'naming_convention_check' in validation_tasks:
             self._collect_naming_convention_check_results(vcf_files, output_dir)
-        if 'eva_sub_cli' in validation_tasks:
-            self._collect_eva_sub_cli_results(output_dir)
+        # eva-sub-cli does not have an associated task, but runs whenever the Nextflow is run and a metadata json exists
+        self._collect_eva_sub_cli_results(output_dir)
 
     def _collect_vcf_check_results(self, vcf_files, output_dir):
         total_error = 0

--- a/eva_submission/nextflow/validation.nf
+++ b/eva_submission/nextflow/validation.nf
@@ -80,7 +80,7 @@ process run_eva_sub_cli {
     script:
     """
     source $params.executable.sub_cli_env
-    $params.executable.eva_sub_cli --submission_dir . --metadata_json ${params.metadata_json} --tasks VALIDATE
+    $params.executable.eva_sub_cli --submission_dir . --metadata_json ${params.metadata_json} --tasks VALIDATE --shallow
     """
 }
 

--- a/eva_submission/nextflow/validation.nf
+++ b/eva_submission/nextflow/validation.nf
@@ -9,7 +9,7 @@ def helpMessage() {
     Inputs:
             --vcf_files_mapping     csv file with the mappings for vcf files, fasta and assembly report
             --output_dir            output_directory where the reports will be output
-            --metadata_json         metadata JSON to be validated with eva-sub-cli
+            --metadata_json         metadata JSON to be validated with eva-sub-cli (optional)
     """
 }
 
@@ -20,7 +20,7 @@ params.metadata_json = null
 params.executable = ["vcf_assembly_checker": "vcf_assembly_checker", "vcf_validator": "vcf_validator", "bgzip": "bgzip",
                      "eva_sub_cli": "eva_sub_cli"]
 // validation tasks
-params.validation_tasks = ["assembly_check", "vcf_check", "structural_variant_check", "naming_convention_check", 'eva_sub_cli']
+params.validation_tasks = ["assembly_check", "vcf_check", "structural_variant_check", "naming_convention_check"]
 // help
 params.help = null
 
@@ -29,10 +29,9 @@ params.help = null
 if (params.help) exit 0, helpMessage()
 
 // Test input files
-if (!params.vcf_files_mapping || !params.output_dir || !params.metadata_json) {
+if (!params.vcf_files_mapping || !params.output_dir) {
     if (!params.vcf_files_mapping)    log.warn('Provide a csv file with the mappings (vcf, fasta, assembly report) --vcf_files_mapping')
     if (!params.output_dir)    log.warn('Provide an output directory where the reports will be copied using --output_dir')
-    if (!params.metadata_json)    log.warn('Provide a metadata JSON to be validated with eva-sub-cli')
     exit 1, helpMessage()
 }
 
@@ -45,7 +44,8 @@ workflow {
         .splitCsv(header:true)
         .map{row -> tuple(file(row.vcf), row.assembly_accession)}
 
-    if ("eva_sub_cli" in params.validation_tasks && params.metadata_json) {
+	// eva-sub-cli does not have an associated task, but runs whenever the Nextflow is run and a metadata json exists
+    if (params.metadata_json) {
         run_eva_sub_cli()
     }
     if ("vcf_check" in params.validation_tasks) {

--- a/eva_submission/nextflow/validation.nf
+++ b/eva_submission/nextflow/validation.nf
@@ -9,13 +9,13 @@ def helpMessage() {
     Inputs:
             --vcf_files_mapping     csv file with the mappings for vcf files, fasta and assembly report
             --output_dir            output_directory where the reports will be output
-            --metadata_xlsx         metadata spreadsheet to be validated with eva-sub-cli
+            --metadata_json         metadata JSON to be validated with eva-sub-cli
     """
 }
 
 params.vcf_files_mapping = null
 params.output_dir = null
-params.metadata_xlsx = null
+params.metadata_json = null
 // executables
 params.executable = ["vcf_assembly_checker": "vcf_assembly_checker", "vcf_validator": "vcf_validator", "bgzip": "bgzip",
                      "eva_sub_cli": "eva_sub_cli"]
@@ -29,10 +29,10 @@ params.help = null
 if (params.help) exit 0, helpMessage()
 
 // Test input files
-if (!params.vcf_files_mapping || !params.output_dir || !params.metadata_xlsx) {
+if (!params.vcf_files_mapping || !params.output_dir || !params.metadata_json) {
     if (!params.vcf_files_mapping)    log.warn('Provide a csv file with the mappings (vcf, fasta, assembly report) --vcf_files_mapping')
     if (!params.output_dir)    log.warn('Provide an output directory where the reports will be copied using --output_dir')
-    if (!params.metadata_xlsx)    log.warn('Provide a metadata spreadsheet to be validated with eva-sub-cli')
+    if (!params.metadata_json)    log.warn('Provide a metadata JSON to be validated with eva-sub-cli')
     exit 1, helpMessage()
 }
 
@@ -45,8 +45,7 @@ workflow {
         .splitCsv(header:true)
         .map{row -> tuple(file(row.vcf), row.assembly_accession)}
 
-
-    if ("eva_sub_cli" in params.validation_tasks) {
+    if ("eva_sub_cli" in params.validation_tasks && params.metadata_json) {
         run_eva_sub_cli()
     }
     if ("vcf_check" in params.validation_tasks) {
@@ -78,7 +77,7 @@ process run_eva_sub_cli {
 
     script:
     """
-    $params.executable.eva_sub_cli --submission_dir . --metadata_xlsx ${params.metadata_xlsx} --tasks VALIDATE
+    $params.executable.eva_sub_cli --submission_dir . --metadata_json ${params.metadata_json} --tasks VALIDATE
     """
 }
 

--- a/eva_submission/nextflow/validation.nf
+++ b/eva_submission/nextflow/validation.nf
@@ -74,6 +74,7 @@ process run_eva_sub_cli {
 
     output:
     path "validation_results.yaml", emit: eva_sub_cli_results
+    path "report.html", emit: eva_sub_cli_report
 
     script:
     """

--- a/eva_submission/nextflow/validation.nf
+++ b/eva_submission/nextflow/validation.nf
@@ -18,7 +18,7 @@ params.output_dir = null
 params.metadata_json = null
 // executables
 params.executable = ["vcf_assembly_checker": "vcf_assembly_checker", "vcf_validator": "vcf_validator", "bgzip": "bgzip",
-                     "eva_sub_cli": "eva_sub_cli"]
+                     "eva_sub_cli": "eva_sub_cli", "sub_cli_env": "sub_cli_env"]
 // validation tasks
 params.validation_tasks = ["assembly_check", "vcf_check", "structural_variant_check", "naming_convention_check"]
 // help
@@ -67,6 +67,7 @@ workflow {
  * Run eva-sub-cli
  */
 process run_eva_sub_cli {
+    label 'long_time', 'med_mem'
 
     publishDir "$params.output_dir",
         overwrite: false,
@@ -74,10 +75,11 @@ process run_eva_sub_cli {
 
     output:
     path "validation_results.yaml", emit: eva_sub_cli_results
-    path "report.html", emit: eva_sub_cli_report
+    path "validation_output/report.html", emit: eva_sub_cli_report
 
     script:
     """
+    source $params.executable.sub_cli_env
     $params.executable.eva_sub_cli --submission_dir . --metadata_json ${params.metadata_json} --tasks VALIDATE
     """
 }

--- a/eva_submission/samples_checker.py
+++ b/eva_submission/samples_checker.py
@@ -4,7 +4,7 @@ import os
 import pysam
 from ebi_eva_common_pyutils.logger import logging_config as log_cfg
 
-from eva_submission.eload_utils import cast_list
+from eva_submission.eload_utils import cast_list, is_vcf_file
 from eva_submission.xlsx.xlsx_parser_eva import EvaXlsxReader
 
 logger = log_cfg.get_logger(__name__)
@@ -98,9 +98,7 @@ def get_vcf_file_paths(file_rows, vcf_dir):
     return [
         os.path.join(vcf_dir, file_row.get('File Name'))
         for file_row in file_rows
-        if (file_row.get('File Type') and file_row.get('File Type') == 'vcf') or
-           (file_row.get('File Name') and file_row.get('File Name').endswith('.vcf')) or
-           (file_row.get('File Name') and file_row.get('File Name').endswith('.vcf.gz'))
+        if is_vcf_file(file_row.get('File Name'))
     ]
 
 

--- a/tests/nextflow-tests/bin/fake_eva_sub_cli.py
+++ b/tests/nextflow-tests/bin/fake_eva_sub_cli.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+import argparse
+import os
+
+
+def touch(f):
+    open(f, 'w').close()
+
+'''
+--submission_dir . --metadata_json ${params.metadata_json} --tasks VALIDATE
+'''
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--submission_dir", required=True)
+    parser.add_argument("--metadata_json", required=True)
+    parser.add_argument("--tasks", required=True)
+    args = parser.parse_args()
+    touch(os.path.join(args.submission_dir, 'report.html'))
+    touch(os.path.join(args.submission_dir, 'validation_results.yaml'))

--- a/tests/nextflow-tests/bin/fake_eva_sub_cli.py
+++ b/tests/nextflow-tests/bin/fake_eva_sub_cli.py
@@ -6,9 +6,6 @@ import os
 def touch(f):
     open(f, 'w').close()
 
-'''
---submission_dir . --metadata_json ${params.metadata_json} --tasks VALIDATE
-'''
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -16,5 +13,6 @@ if __name__ == '__main__':
     parser.add_argument("--metadata_json", required=True)
     parser.add_argument("--tasks", required=True)
     args = parser.parse_args()
-    touch(os.path.join(args.submission_dir, 'report.html'))
+    os.mkdir(os.path.join(args.submission_dir, 'validation_output'))
+    touch(os.path.join(args.submission_dir, 'validation_output/report.html'))
     touch(os.path.join(args.submission_dir, 'validation_results.yaml'))

--- a/tests/nextflow-tests/bin/fake_eva_sub_cli.py
+++ b/tests/nextflow-tests/bin/fake_eva_sub_cli.py
@@ -12,6 +12,7 @@ if __name__ == '__main__':
     parser.add_argument("--submission_dir", required=True)
     parser.add_argument("--metadata_json", required=True)
     parser.add_argument("--tasks", required=True)
+    parser.add_argument("--shallow", required=True, action="store_true")
     args = parser.parse_args()
     os.mkdir(os.path.join(args.submission_dir, 'validation_output'))
     touch(os.path.join(args.submission_dir, 'validation_output/report.html'))

--- a/tests/nextflow-tests/run_tests_validation.sh
+++ b/tests/nextflow-tests/run_tests_validation.sh
@@ -17,7 +17,7 @@ output/assembly_check/test1.vcf.gz.assembly_check.log \
 output/assembly_check/test1.vcf.gz.text_assembly_report \
 output/assembly_check/test1.vcf.gz.valid_assembly_report \
 output/validation_results.yaml \
-output/report.html
+output/validation_output/report.html
 
 
 # clean up

--- a/tests/nextflow-tests/run_tests_validation.sh
+++ b/tests/nextflow-tests/run_tests_validation.sh
@@ -15,7 +15,9 @@ ls output/sv_check/test1.vcf_sv_check.log \
 output/sv_check/test1.vcf_sv_list.vcf.gz \
 output/assembly_check/test1.vcf.gz.assembly_check.log \
 output/assembly_check/test1.vcf.gz.text_assembly_report \
-output/assembly_check/test1.vcf.gz.valid_assembly_report
+output/assembly_check/test1.vcf.gz.valid_assembly_report \
+output/validation_results.yaml \
+output/report.html
 
 
 # clean up

--- a/tests/nextflow-tests/test_validation_config.yaml
+++ b/tests/nextflow-tests/test_validation_config.yaml
@@ -1,11 +1,13 @@
 vcf_files_mapping: vcf_files_to_validate.csv
 output_dir: output
+metadata_json: fake_metadata.json
 
 executable:
   vcf_validator: ../../../bin/fake_vcf_validator.sh
   vcf_assembly_checker: ../../../bin/fake_assembly_checker.sh
   bcftools: ../../../bin/fake_bcftools.sh
   bgzip: ../../../bin/fake_bgzip.sh
+  eva_sub_cli: ../../../bin/fake_eva_sub_cli.py
   python:
     script_path: ../../../../../
     interpreter: '`which python`'

--- a/tests/nextflow-tests/test_validation_config.yaml
+++ b/tests/nextflow-tests/test_validation_config.yaml
@@ -8,6 +8,7 @@ executable:
   bcftools: ../../../bin/fake_bcftools.sh
   bgzip: ../../../bin/fake_bgzip.sh
   eva_sub_cli: ../../../bin/fake_eva_sub_cli.py
+  sub_cli_env: ../../../bin/venv_activate
   python:
     script_path: ../../../../../
     interpreter: '`which python`'

--- a/tests/test_eload_preparation.py
+++ b/tests/test_eload_preparation.py
@@ -181,6 +181,7 @@ class TestEloadPreparation(TestCase):
         assert 'assemblyReport' not in original_metadata['analysis'][1]
         assert original_metadata['analysis'][2]['referenceFasta'] == 'GCA_000001405.27_fasta.fa'
         assert 'assemblyReport' not in original_metadata['analysis'][2]
+        assert original_metadata['files'][0]['fileName'] == 'example1.vcf.gz'
 
         self.eload.update_metadata_json_if_required(taxid=10000)
 
@@ -194,3 +195,4 @@ class TestEloadPreparation(TestCase):
         assert updated_metadata['analysis'][1]['assemblyReport'] == 'GCA_000001111.1_report.txt'
         assert updated_metadata['analysis'][2]['referenceFasta'] == 'GCA_000001405.27_fasta.fa'
         assert 'assemblyReport' not in updated_metadata['analysis'][2]
+        assert 'ELOAD_1/10_submitted/vcf_files' in updated_metadata['files'][0]['fileName']

--- a/tests/test_eload_preparation.py
+++ b/tests/test_eload_preparation.py
@@ -166,10 +166,10 @@ class TestEloadPreparation(TestCase):
         self.eload.eload_cfg.set('submission', 'metadata_json', value=json_copy)
 
         # fasta and assembly report determined by find_genome
-        self.eload.eload_cfg.set('submission', 'analyses', 'VD1', 'assembly_fasta', value='GCA_000009999.9_fasta.fa')
-        self.eload.eload_cfg.set('submission', 'analyses', 'VD1', 'assembly_report', value='GCA_000009999.9_report.txt')
-        self.eload.eload_cfg.set('submission', 'analyses', 'VD2', 'assembly_fasta', value='GCA_000001111.1_fasta.fa')
-        self.eload.eload_cfg.set('submission', 'analyses', 'VD2', 'assembly_report', value='GCA_000001111.1_report.txt')
+        self.eload.eload_cfg.set('submission', 'analyses', 'ELOAD_1_VD1', 'assembly_fasta', value='GCA_000009999.9_fasta.fa')
+        self.eload.eload_cfg.set('submission', 'analyses', 'ELOAD_1_VD1', 'assembly_report', value='GCA_000009999.9_report.txt')
+        self.eload.eload_cfg.set('submission', 'analyses', 'ELOAD_1_VD2', 'assembly_fasta', value='GCA_000001111.1_fasta.fa')
+        self.eload.eload_cfg.set('submission', 'analyses', 'ELOAD_1_VD2', 'assembly_report', value='GCA_000001111.1_report.txt')
 
         # assert initial state of metadata
         with open(json_copy) as open_json:

--- a/tests/test_eload_preparation.py
+++ b/tests/test_eload_preparation.py
@@ -1,4 +1,5 @@
 import glob
+import json
 import os
 import shutil
 from unittest import TestCase, mock
@@ -141,16 +142,55 @@ class TestEloadPreparation(TestCase):
     def test_convert_new_spreadsheet_to_eload_spreadsheet_if_required(self):
         metadata_example = os.path.join(eva_sub_cli.ETC_DIR , 'EVA_Submission_Example.xlsx')
         metadata_dir = self.eload._get_dir('metadata')
-        self.eload.eload_cfg.set('submission', 'metadata_spreadsheet', value=metadata_example)
+        # Make a copy so we preserve the example spreadsheet
+        metadata_copy = shutil.copy(metadata_example, os.path.join(metadata_dir, 'metadata.xlsx'))
+        self.eload.eload_cfg.set('submission', 'metadata_spreadsheet', value=metadata_copy)
+
         self.eload.convert_new_spreadsheet_to_eload_spreadsheet_if_required()
-        assert os.path.isfile(os.path.join(metadata_dir, 'eva_sub_cli', os.path.basename(metadata_example)))
-        assert os.path.isfile(os.path.join(metadata_dir, os.path.basename(metadata_example)))
-        metadata_xlsx = os.path.join(metadata_dir, os.path.basename(metadata_example))
+        assert os.path.isfile(os.path.join(metadata_dir, 'eva_sub_cli', os.path.basename(metadata_copy)))
+        assert os.path.isfile(os.path.join(metadata_dir, os.path.basename(metadata_copy)))
+        metadata_xlsx = os.path.join(metadata_dir, os.path.basename(metadata_copy))
         version = metadata_xlsx_version(metadata_xlsx)
         assert version == '1.1.4'
         reader = EvaXlsxReader(metadata_xlsx)
         assert reader.project['Project Title'] == 'Investigation of human genetic variants'
         assert reader.analysis[0]['Analysis Title'] == 'Human genetic variation analysis'
+        assert self.eload.eload_cfg.query('submission', 'metadata_json') == os.path.join(metadata_dir, 'eva_sub_cli',
+                                                                                         'eva_sub_cli_metadata.json')
 
+    def test_update_metadata_json_if_required(self):
+        json_example = os.path.join(self.resources_folder, 'input_json_for_json_to_xlsx_converter.json')
+        metadata_dir = self.eload._get_dir('metadata')
+        # Make a copy so we preserve the example json
+        json_copy = shutil.copy(json_example, os.path.join(metadata_dir, 'metadata.json'))
+        self.eload.eload_cfg.set('submission', 'metadata_json', value=json_copy)
 
+        # fasta and assembly report determined by find_genome
+        self.eload.eload_cfg.set('submission', 'analyses', 'VD1', 'assembly_fasta', value='GCA_000009999.9_fasta.fa')
+        self.eload.eload_cfg.set('submission', 'analyses', 'VD1', 'assembly_report', value='GCA_000009999.9_report.txt')
+        self.eload.eload_cfg.set('submission', 'analyses', 'VD2', 'assembly_fasta', value='GCA_000001111.1_fasta.fa')
+        self.eload.eload_cfg.set('submission', 'analyses', 'VD2', 'assembly_report', value='GCA_000001111.1_report.txt')
 
+        # assert initial state of metadata
+        with open(json_copy) as open_json:
+            original_metadata = json.load(open_json)
+        assert original_metadata['project']['taxId'] == 9606
+        assert original_metadata['analysis'][0]['referenceFasta'] == 'GCA_000001405.27_fasta.fa'
+        assert 'assemblyReport' not in original_metadata['analysis'][0]
+        assert original_metadata['analysis'][1]['referenceFasta'] == 'GCA_000001405.27_fasta.fa'
+        assert 'assemblyReport' not in original_metadata['analysis'][1]
+        assert original_metadata['analysis'][2]['referenceFasta'] == 'GCA_000001405.27_fasta.fa'
+        assert 'assemblyReport' not in original_metadata['analysis'][2]
+
+        self.eload.update_metadata_json_if_required(taxid=10000)
+
+        # assert updated metadata
+        with open(json_copy) as open_json:
+            updated_metadata = json.load(open_json)
+        assert updated_metadata['project']['taxId'] == 10000
+        assert updated_metadata['analysis'][0]['referenceFasta'] == 'GCA_000009999.9_fasta.fa'
+        assert updated_metadata['analysis'][0]['assemblyReport'] == 'GCA_000009999.9_report.txt'
+        assert updated_metadata['analysis'][1]['referenceFasta'] == 'GCA_000001111.1_fasta.fa'
+        assert updated_metadata['analysis'][1]['assemblyReport'] == 'GCA_000001111.1_report.txt'
+        assert updated_metadata['analysis'][2]['referenceFasta'] == 'GCA_000001405.27_fasta.fa'
+        assert 'assemblyReport' not in updated_metadata['analysis'][2]

--- a/tests/test_eload_validation.py
+++ b/tests/test_eload_validation.py
@@ -149,6 +149,10 @@ Naming convention check:
     * test.vcf: enaSequenceName
 
 ----------------------------------
+
+eva-sub-cli:
+Did not run
+----------------------------------
 '''
         print(self.validation.report())
         with patch('builtins.print') as mprint:

--- a/tests/test_sub_cli_processing/test_sub_cli_to_eload_converter.py
+++ b/tests/test_sub_cli_processing/test_sub_cli_to_eload_converter.py
@@ -156,6 +156,8 @@ class TestSubCliToEloadConverter(TestCase):
 
     def test_contig_alias_db_update(self):
         cfg.content['eutils_api_key'] = None
+        # Ensure no other analyses present in the config
+        self.cli_to_eload.eload_cfg.set('submission', 'analyses', value={})
         self.cli_to_eload.eload_cfg.set('submission', 'scientific_name', value='Thingy thingus')
         self.cli_to_eload.eload_cfg.set('submission', 'analyses', 'Analysis alias test', 'assembly_accession',
                                         value='GCA_000001405.10')

--- a/tests/test_sub_cli_processing/test_sub_cli_to_eload_converter.py
+++ b/tests/test_sub_cli_processing/test_sub_cli_to_eload_converter.py
@@ -93,6 +93,7 @@ class TestSubCliToEloadConverter(TestCase):
                                                'metadata_xlsx.xlsx')
         assert os.path.exists(metadata_json_file_path)
         assert os.path.exists(metadata_xlsx_file_path)
+        assert self.cli_to_eload.eload_cfg.query('submission', 'metadata_json') == metadata_json_file_path
 
     def test_detect_submitted_metadata(self):
         self.create_vcfs()


### PR DESCRIPTION
Also replaces all references to "File type" with checks on the file extension.

Implementation notes:
* eva-sub-cli only runs if metadata JSON is present - so for CLI submissions or email submissions using the new spreadsheet. In these cases the prepare script will update the JSON and add its location to the ELOAD config.
* It does not have its own validation task, this means it runs if and only if the validation Nextflow runs (and JSON exists)
* Does not have a pass/fail state and so doesn't block anything if it fails or doesn't run, obviously can't be forced either
* Appears at the bottom of the validation report as "Did not run", failed to run or a link to the HTML report in the validations folder
* Runs **shallow** validation
* Requires two additions to the submission config, the eva-sub-cli executable and the `activate` executable for eva-sub-cli's dependencies to be added to PATH