### PR TITLE
Sample checker to check Sample ID before Sample Name

### DIFF
--- a/eva_sub_cli_processing/sub_cli_to_eload_converter/json_to_xlsx_converter.py
+++ b/eva_sub_cli_processing/sub_cli_to_eload_converter/json_to_xlsx_converter.py
@@ -107,7 +107,7 @@ json_to_xlsx_key_mapper = {
         "subSpecies": "sub_species",
         "variety": "variety",
         "subStrain": "sub_strain",
-        "cellType": "cell_line",
+        "cellLine": "cell_line",
         "serotype": "serotype",
         "serovar": "serovar"
     },

--- a/eva_submission/samples_checker.py
+++ b/eva_submission/samples_checker.py
@@ -50,10 +50,10 @@ def get_sample_names(sample_rows):
     """
     sample_names = []
     for row in sample_rows:
-        if 'Sample Name' in row and row['Sample Name']:
-            sample_names.append(row['Sample Name'])
-        elif 'Sample ID' in row and row['Sample ID']:
+        if 'Sample ID' in row and row['Sample ID']:
             sample_names.append(row['Sample ID'])
+        elif 'Sample Name' in row and row['Sample Name']:
+            sample_names.append(row['Sample Name'])
         else:
             logger.warning('Sample Name and sample ID are both missing in row %s', row.get('row_num'))
 

--- a/tests/test_samples_checker.py
+++ b/tests/test_samples_checker.py
@@ -16,11 +16,6 @@ class TestSampleChecker(TestCase):
     def test_get_sample_names(self):
         assert get_sample_names([{'Sample Name': 'S1'}, {'Sample ID': 'S2'}, {'Analysis': ''}]) == ['S1', 'S2']
 
-
-class TestSampleChecker(TestCase):
-
-    resources_folder = os.path.join(ROOT_DIR, 'tests', 'resources')
-
     def test_compare_names_in_files_and_samples(self):
         assert compare_names_in_files_and_samples(
             [os.path.join(self.resources_folder, 'test.vcf')],
@@ -39,5 +34,3 @@ class TestSampleChecker(TestCase):
         vcf_dir = os.path.join(self.resources_folder, 'vcf_dir')
         results_per_analysis_alias = compare_spreadsheet_and_vcf(metadata_file, vcf_dir)
         assert results_per_analysis_alias == {'GAE': (False, [], []), 'GAE2': (False, [], [])}
-
-


### PR DESCRIPTION
As `sampleInVcf` is mapped to `Sample ID` in the converter [converter](https://github.com/EBIvariation/eva-submission/blob/master/eva_sub_cli_processing/sub_cli_to_eload_converter/json_to_xlsx_converter.py#L70), this column should take precedence in the sample check.