### PR TITLE
EVA-4185: Update release date after brokering to ENA

### DIFF
--- a/bin/update_release_date.py
+++ b/bin/update_release_date.py
@@ -70,7 +70,7 @@ def main():
                         help='Target submission by UUID')
     target.add_argument('--eload_id', required=False, type=int,
                         help='Target submission by ELOAD number (resolved to UUID via API)')
-    argparse.add_argument('--release_date', required=True, type='str',
+    argparse.add_argument('--release_date', required=True, type=str,
                           help='Release date in ISO-8601 format (e.g. 2027-01-31)')
     argparse.add_argument('--debug', action='store_true', default=False,
                           help='Set the script to output logging information at debug level')

--- a/bin/update_release_date.py
+++ b/bin/update_release_date.py
@@ -96,11 +96,15 @@ def main():
             logger.error(f'Submission {submission_id} not found')
             sys.exit(1)
 
-    project_accession = submission.get('projectAccession') or 'None'
+    project_accession = submission.get('projectAccession')
     old_release_date = submission.get('releaseDate') or 'None'
 
+    if not project_accession:
+        logger.error(f'Could not determine project accession for submission {submission_id}')
+        sys.exit(1)
     update_ena_release_date(project_accession, args.release_date)
-    put_to_sub_ws(sub_ws_url_build('admin', 'submission', submission_id, 'releaseDate', args.release_date))
+    put_to_sub_ws(sub_ws_url_build('admin', 'submission', submission_id, 'trackingDetails'),
+                  {'releaseDate': args.release_date})
     logger.info(f'Updated submission {submission_id}: {old_release_date} -> {args.release_date}')
 
 

--- a/bin/update_release_date.py
+++ b/bin/update_release_date.py
@@ -17,7 +17,11 @@ import logging
 import sys
 from argparse import ArgumentParser
 
+import requests
+from ebi_eva_common_pyutils.config import cfg
 from ebi_eva_common_pyutils.logger import logging_config as log_cfg
+from requests.auth import HTTPBasicAuth
+from retry import retry
 
 from eva_sub_cli_processing.sub_cli_utils import (
     put_to_sub_ws, sub_ws_url_build, fetch_submission_from_eload, fetch_submission
@@ -26,6 +30,38 @@ from eva_submission.submission_config import load_config
 
 logger = log_cfg.get_logger(__name__)
 
+
+@retry(requests.exceptions.ConnectionError, tries=3, delay=2, backoff=1.2, jitter=(1, 3))
+def update_ena_release_date(project_accession, release_date):
+    body = {
+        "submission": {
+            "accession": project_accession,
+            "actions": [
+                {
+                    "type": "HOLD",
+                    "target": project_accession,
+                    "holdUntilDate": release_date
+                }
+            ]
+        }
+    }
+    ena_auth = HTTPBasicAuth(cfg.query('ena', 'username'), cfg.query('ena', 'password'))
+    ena_url = cfg.query('ena', 'submit_url')
+    response = requests.post(ena_url, auth=ena_auth, data=body, headers={'Accept': 'application/json'})
+    response.raise_for_status()
+
+    # Check for error messages in ENA receipt
+    try:
+        receipt = response.json()
+        messages = receipt.get('messages')
+        if 'error' in messages:
+            logger.error(f'Failed to update release date for {project_accession} on ENA. Error: {messages["error"]}')
+            sys.exit(1)
+        else:
+            logger.info(f'Updated release date for {project_accession} on ENA')
+    except Exception as e:
+        logger.error(f'Failed to update release date for {project_accession} on ENA. Error: {e}')
+        sys.exit(1)
 
 def main():
     argparse = ArgumentParser(description='Update the release date of a submission in the submission webservice')
@@ -60,8 +96,10 @@ def main():
             logger.error(f'Submission {submission_id} not found')
             sys.exit(1)
 
+    project_accession = submission.get('projectAccession') or 'None'
     old_release_date = submission.get('releaseDate') or 'None'
 
+    update_ena_release_date(project_accession, args.release_date)
     put_to_sub_ws(sub_ws_url_build('admin', 'submission', submission_id, 'releaseDate', args.release_date))
     logger.info(f'Updated submission {submission_id}: {old_release_date} -> {args.release_date}')
 

--- a/bin/update_release_date.py
+++ b/bin/update_release_date.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 # Copyright 2026 EMBL - European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,7 +20,7 @@ from argparse import ArgumentParser
 from ebi_eva_common_pyutils.logger import logging_config as log_cfg
 
 from eva_sub_cli_processing.sub_cli_utils import (
-    put_to_sub_ws, sub_ws_url_build, PROCESSING_STEPS, PROCESSING_STATUS, fetch_submission_from_eload, fetch_submission
+    put_to_sub_ws, sub_ws_url_build, fetch_submission_from_eload, fetch_submission
 )
 from eva_submission.submission_config import load_config
 
@@ -29,16 +28,14 @@ logger = log_cfg.get_logger(__name__)
 
 
 def main():
-    argparse = ArgumentParser(description='Update the processing status of a submission in the submission webservice')
+    argparse = ArgumentParser(description='Update the release date of a submission in the submission webservice')
     target = argparse.add_mutually_exclusive_group(required=True)
     target.add_argument('--submission_id', required=False, type=str,
                         help='Target submission by UUID')
     target.add_argument('--eload_id', required=False, type=int,
                         help='Target submission by ELOAD number (resolved to UUID via API)')
-    argparse.add_argument('--step', required=True, choices=PROCESSING_STEPS,
-                          help='Processing step to update')
-    argparse.add_argument('--status', required=True, choices=PROCESSING_STATUS,
-                          help='New processing status')
+    argparse.add_argument('--release_date', required=True, type='str',
+                          help='Release date in ISO-8601 format (e.g. 2027-01-31)')
     argparse.add_argument('--debug', action='store_true', default=False,
                           help='Set the script to output logging information at debug level')
     args = argparse.parse_args()
@@ -63,11 +60,10 @@ def main():
             logger.error(f'Submission {submission_id} not found')
             sys.exit(1)
 
-    old_step = submission.get('processingStep') or 'None'
-    old_status = submission.get('processingStatus') or 'None'
+    old_release_date = submission.get('releaseDate') or 'None'
 
-    put_to_sub_ws(sub_ws_url_build('admin', 'submission-process', submission_id, args.step, args.status))
-    logger.info(f'Updated submission {submission_id}: {old_step}/{old_status} -> {args.step}/{args.status}')
+    put_to_sub_ws(sub_ws_url_build('admin', 'submission', submission_id, 'releaseDate', args.release_date))
+    logger.info(f'Updated submission {submission_id}: {old_release_date} -> {args.release_date}')
 
 
 if __name__ == '__main__':

--- a/bin/update_release_date.py
+++ b/bin/update_release_date.py
@@ -32,6 +32,7 @@ logger = log_cfg.get_logger(__name__)
 
 
 @retry(requests.exceptions.ConnectionError, tries=3, delay=2, backoff=1.2, jitter=(1, 3))
+# FIXME: currently fails with 415 response from ENA
 def update_ena_release_date(project_accession, release_date):
     body = {
         "submission": {

--- a/eva_sub_cli_processing/sub_cli_utils.py
+++ b/eva_sub_cli_processing/sub_cli_utils.py
@@ -1,5 +1,3 @@
-import json
-
 import requests
 from ebi_eva_common_pyutils.config import cfg
 from retry import retry
@@ -62,5 +60,20 @@ def put_to_sub_ws(url, json_data=None):
     response.raise_for_status()
     if not response.text:
         return None
-
     return response.json()
+
+
+def fetch_submission_from_eload(eload_id):
+    response = get_from_sub_ws(sub_ws_url_build('admin', 'submissions', eloadId=eload_id, size=1))
+    content = response.get('content', [])
+    if not content:
+        return None
+    return content[0]
+
+
+def fetch_submission(submission_id):
+    response = get_from_sub_ws(sub_ws_url_build('admin', 'submissions', submissionId=submission_id, size=1))
+    content = response.get('content', [])
+    if not content:
+        return None
+    return content[0]

--- a/eva_submission/ENA_submission/json_to_ENA_xml.py
+++ b/eva_submission/ENA_submission/json_to_ENA_xml.py
@@ -236,7 +236,10 @@ class EnaJson2XmlConverter(EnaJsonConverter):
         else:
             hold_date = today() + timedelta(days=3)
 
-        self.hold_date = hold_date
+        # Make sure the hold date is in 'YYYY-MM-DD' format
+        self.hold_date = (
+            hold_date.strftime('%Y-%m-%d') if isinstance(hold_date, datetime) else hold_date
+        )
         action_elemt = add_element(actions_elemt, 'ACTION')
         if isinstance(hold_date, datetime):
             hold_date_str = hold_date.strftime('%Y-%m-%d')

--- a/eva_submission/eload_brokering.py
+++ b/eva_submission/eload_brokering.py
@@ -105,8 +105,10 @@ class EloadBrokering(Eload):
                 self.eload_cfg.set('brokering', 'ena', 'hold_date', value=ena_uploader.converter.hold_date)
                 self.eload_cfg.set('brokering', 'ena', 'pass', value=not bool(ena_uploader.results['errors']))
 
-                # Set release date in submission-ws
-                self.set_release_date(ena_uploader.converter.hold_date)
+                # Set release date, project accession, and analysis accessions in submission-ws
+                self.set_release_date_in_ws(ena_uploader.converter.hold_date)
+                self.set_project_and_analysis_in_ws(ena_uploader.results['PROJECT'],
+                                                    list(ena_uploader.results.get('ANALYSIS', {}).values()))
         else:
             self.info('Brokering to ENA has already been run, Skip!')
 
@@ -412,7 +414,7 @@ Archival Confirmation Text:
         else:
             self.update_submission_status(sub_cli_utils.BROKERING, sub_cli_utils.FAILURE)
 
-    def set_release_date(self, release_date):
+    def set_release_date_in_ws(self, release_date):
         try:
             if self.submission_id:
                 put_to_sub_ws(sub_ws_url_build('admin', 'submission', self.submission_id, 'releaseDate',
@@ -422,3 +424,17 @@ Archival Confirmation Text:
                     f'Could not update release date to {release_date} as no submission id provided for Eload {self.eload}')
         except Exception as e:
             self.warning(f'Could not update release date to {release_date}. Error {e}')
+
+    def set_project_and_analysis_in_ws(self, project_accession, analysis_accessions):
+        try:
+            if self.submission_id:
+                body = {
+                    'projectAccession': project_accession,
+                    'analysisAccessions': analysis_accessions
+                }
+                put_to_sub_ws(sub_ws_url_build('admin', 'submission', self.submission_id, 'accessions'), body)
+            else:
+                self.warning(
+                    f'Could not update project and analysis accessions as no submission id provided for Eload {self.eload}')
+        except Exception as e:
+            self.warning(f'Could not update project and analysis accessions. Error {e}')

--- a/eva_submission/eload_brokering.py
+++ b/eva_submission/eload_brokering.py
@@ -418,7 +418,7 @@ Archival Confirmation Text:
         try:
             if self.submission_id:
                 put_to_sub_ws(sub_ws_url_build('admin', 'submission', self.submission_id, 'releaseDate',
-                                               release_date.strftime('%Y-%m-%d')))
+                                               release_date))
             else:
                 self.warning(
                     f'Could not update release date to {release_date} as no submission id provided for Eload {self.eload}')

--- a/eva_submission/eload_brokering.py
+++ b/eva_submission/eload_brokering.py
@@ -10,6 +10,7 @@ from ebi_eva_common_pyutils import command_utils
 from ebi_eva_common_pyutils.config import cfg
 
 from eva_sub_cli_processing import sub_cli_utils
+from eva_sub_cli_processing.sub_cli_utils import put_to_sub_ws, sub_ws_url_build
 from eva_submission import NEXTFLOW_DIR
 from eva_submission.ENA_submission.upload_to_ENA import ENAUploader, ENAUploaderAsync
 from eva_submission.biosample_submission.biosamples_submitters import SampleMetadataSubmitter, SampleReferenceSubmitter, \
@@ -103,6 +104,9 @@ class EloadBrokering(Eload):
                 self.eload_cfg.set('brokering', 'ena', 'date', value=self.now)
                 self.eload_cfg.set('brokering', 'ena', 'hold_date', value=ena_uploader.converter.hold_date)
                 self.eload_cfg.set('brokering', 'ena', 'pass', value=not bool(ena_uploader.results['errors']))
+
+                # Set release date in submission-ws
+                self.set_release_date(ena_uploader.converter.hold_date)
         else:
             self.info('Brokering to ENA has already been run, Skip!')
 
@@ -407,3 +411,14 @@ Archival Confirmation Text:
             self.update_submission_status(sub_cli_utils.BROKERING, sub_cli_utils.SUCCESS)
         else:
             self.update_submission_status(sub_cli_utils.BROKERING, sub_cli_utils.FAILURE)
+
+    def set_release_date(self, release_date):
+        try:
+            if self.submission_id:
+                put_to_sub_ws(sub_ws_url_build('admin', 'submission', self.submission_id, 'releaseDate',
+                                               release_date.strftime('%Y-%m-%d')))
+            else:
+                self.warning(
+                    f'Could not update release date to {release_date} as no submission id provided for Eload {self.eload}')
+        except Exception as e:
+            self.warning(f'Could not update release date to {release_date}. Error {e}')

--- a/eva_submission/eload_brokering.py
+++ b/eva_submission/eload_brokering.py
@@ -106,9 +106,9 @@ class EloadBrokering(Eload):
                 self.eload_cfg.set('brokering', 'ena', 'pass', value=not bool(ena_uploader.results['errors']))
 
                 # Set release date, project accession, and analysis accessions in submission-ws
-                self.set_release_date_in_ws(ena_uploader.converter.hold_date)
-                self.set_project_and_analysis_in_ws(ena_uploader.results['PROJECT'],
-                                                    list(ena_uploader.results.get('ANALYSIS', {}).values()))
+                self.update_tracking_details(ena_uploader.converter.hold_date,
+                                             ena_uploader.results['PROJECT'],
+                                             list(ena_uploader.results.get('ANALYSIS', {}).values()))
         else:
             self.info('Brokering to ENA has already been run, Skip!')
 
@@ -414,27 +414,17 @@ Archival Confirmation Text:
         else:
             self.update_submission_status(sub_cli_utils.BROKERING, sub_cli_utils.FAILURE)
 
-    def set_release_date_in_ws(self, release_date):
-        try:
-            if self.submission_id:
-                put_to_sub_ws(sub_ws_url_build('admin', 'submission', self.submission_id, 'releaseDate',
-                                               release_date))
-            else:
-                self.warning(
-                    f'Could not update release date to {release_date} as no submission id provided for Eload {self.eload}')
-        except Exception as e:
-            self.warning(f'Could not update release date to {release_date}. Error {e}')
-
-    def set_project_and_analysis_in_ws(self, project_accession, analysis_accessions):
+    def update_tracking_details(self, release_date, project_accession, analysis_accessions):
         try:
             if self.submission_id:
                 body = {
+                    'releaseDate': release_date,
                     'projectAccession': project_accession,
                     'analysisAccessions': analysis_accessions
                 }
-                put_to_sub_ws(sub_ws_url_build('admin', 'submission', self.submission_id, 'accessions'), body)
+                put_to_sub_ws(sub_ws_url_build('admin', 'submission', self.submission_id, 'trackingDetails'), body)
             else:
                 self.warning(
-                    f'Could not update project and analysis accessions as no submission id provided for Eload {self.eload}')
+                    f'Could not update tracking details as no submission id provided for Eload {self.eload}')
         except Exception as e:
-            self.warning(f'Could not update project and analysis accessions. Error {e}')
+            self.warning(f'Could not update submission tracking details. Error {e}')

--- a/tests/test_eload_brokering.py
+++ b/tests/test_eload_brokering.py
@@ -21,6 +21,48 @@ class TestEloadBrokering(TestCase):
     top_dir = os.path.dirname(os.path.dirname(__file__))
     resources_folder = os.path.join(os.path.dirname(__file__), 'resources')
 
+    ena_receipt_xml = '''<?xml version="1.0" encoding="UTF-8"?>
+        <?xml-stylesheet type="text/xsl" href="receipt.xsl"?>
+        <RECEIPT receiptDate="2020-12-21T16:23:42.950Z" submissionFile="ELOAD_733.Submission.xml" success="true">
+             <ANALYSIS accession="ERZ1695006" alias="FGV analysis b" status="PRIVATE"/>
+             <PROJECT accession="PRJEB42220" alias="ICFADS2b" status="PRIVATE" holdUntilDate="2022-12-21Z">
+                  <EXT_ID accession="ERP126058" type="study"/>
+             </PROJECT>
+             <SUBMISSION accession="ERA3202812" alias="ICFADS2b"/>
+             <MESSAGES>
+                  <INFO>Submission has been committed.</INFO>
+             </MESSAGES>
+             <ACTIONS>ADD</ACTIONS>
+             <ACTIONS>ADD</ACTIONS>
+        </RECEIPT>'''
+    ena_receipt_json = '''{
+      "success" : true,
+      "receiptDate" : "2020-12-21T16:23:42.950Z",
+      "projects" : [ {
+        "alias" : "ICFADS2b",
+        "accession" : "PRJEB42220",
+        "status" : "PRIVATE",
+        "holdUntilDate" : "2022-12-21Z",
+        "externalAccession" : {
+          "id" : "ERP126058",
+          "db" : "study"
+        }
+      } ],
+      "submission" : {
+        "alias" : "SICFADS2b",
+        "accession" : "ERA3202812"
+      },
+      "analyses": [ {
+          "accession" : "ERZ1695006",
+          "alias": "FGV analysis b",
+          "status" : "PRIVATE"
+      }],
+      "messages" : {
+        "info" : [ "Submission has been committed." ]
+      },
+      "actions" : [ "ADD", "ADD" ]
+    }'''
+
     def setUp(self) -> None:
         config_file = os.path.join(self.resources_folder, 'submission_config.yml')
         load_config(config_file)
@@ -86,7 +128,7 @@ class TestEloadBrokering(TestCase):
         self.eload.eload_cfg.set('validation', 'valid', 'metadata_spreadsheet',
                                  value=os.path.join(self.resources_folder, 'metadata.xlsx'))
         self.eload.eload_cfg.set('brokering', 'analyses', value={'AA1':{'vcf_files':{}}})
-        response = Mock(text='', headers={'Content-Type': 'application/xml'})
+        response = Mock(text=self.ena_receipt_xml, headers={'Content-Type': 'application/xml'})
         with patch.object(ENAUploader, 'upload_vcf_files_to_ena_ftp'),\
               patch.object(ENAUploader, '_post_metadata_file_to_ena', return_value=response):
             self.eload.broker_to_ena()
@@ -95,9 +137,12 @@ class TestEloadBrokering(TestCase):
         self.eload.eload_cfg.set('validation', 'valid', 'metadata_json',
                                  value=os.path.join(self.resources_folder, 'brokering', 'eva_metadata_json.json'))
         self.eload.eload_cfg.set('brokering', 'analyses', value={'AA1':{'vcf_files':{}}})
-        response = Mock(text='', headers={'Content-Type': 'application/json'})
+        upload_response = Mock(text='{"submissionId": 123, "_links": {"poll": {"href": "http://mock-poll.com/123"}}}',
+                               headers={'Content-Type': 'application/json'}, status_code=200)
+        poll_response = Mock(text=self.ena_receipt_json, headers={'Content-Type': 'application/json'})
         with patch.object(ENAUploader, 'upload_vcf_files_to_ena_ftp'),\
-              patch.object(ENAUploader, '_post_metadata_file_to_ena', return_value=response):
+              patch.object(ENAUploader, '_post_metadata_file_to_ena', return_value=upload_response),\
+              patch('eva_submission.ENA_submission.upload_to_ENA.requests.get', return_value=poll_response):
             self.eload.broker_to_ena(async_upload=True)
 
     def test_broker_to_ena_json_existing_project(self):


### PR DESCRIPTION
Also add a dedicated script for updating the release date manually, though the ENA update currently isn't working and should be fixed in a subsequent PR.

Integration tests [here](https://github.com/EBIvariation/eva-integration-tests/pull/71)