### PR TITLE
EVA-4182: Allow main scripts to accept submission ID as well as eload

### DIFF
--- a/bin/broker_submission.py
+++ b/bin/broker_submission.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import logging
+import sys
 from argparse import ArgumentParser
 
 from ebi_eva_common_pyutils.logger import logging_config as log_cfg
@@ -37,7 +38,10 @@ def ENA_Project(project):
 
 def main():
     argparse = ArgumentParser(description='Broker validated ELOAD to BioSamples and ENA')
-    argparse.add_argument('--eload', required=True, type=int, help='The ELOAD number for this submission')
+    target = argparse.add_mutually_exclusive_group(required=True)
+    target.add_argument('--submission_id', required=False, type=str,
+                        help='Submission ID, converted to ELOAD for downstream processing')
+    target.add_argument('--eload', required=False, type=int, help='The ELOAD number for this submission')
     argparse.add_argument('--debug', action='store_true', default=False,
                           help='Set the script to output logging information at debug level')
     argparse.add_argument('--project_accession', required=False, type=ENA_Project,
@@ -69,7 +73,17 @@ def main():
 
     # Load the config_file from default location
     load_config()
-    with EloadBrokering(args.eload, nextflow_config=args.nextflow_config) as brokering:
+
+    if args.submission_id:
+        submission = sub_cli_utils.fetch_submission(args.submission_id)
+        if not submission:
+            logger.error(f'Submission {args.submission_id} not found')
+            sys.exit(1)
+        eload_id = submission.get('eloadId')
+    else:
+        eload_id = args.eload
+
+    with EloadBrokering(eload_id, nextflow_config=args.nextflow_config) as brokering:
         brokering.upgrade_to_new_version_if_needed()
         if not args.report:
             try:

--- a/bin/delete_submission.py
+++ b/bin/delete_submission.py
@@ -15,10 +15,12 @@
 # limitations under the License.
 
 import logging
+import sys
 from argparse import ArgumentParser
 
 from ebi_eva_common_pyutils.logger import logging_config as log_cfg
 
+from eva_sub_cli_processing.sub_cli_utils import fetch_submission
 from eva_submission.eload_deletion import EloadDeletion
 from eva_submission.submission_config import load_config
 
@@ -27,7 +29,10 @@ logger = log_cfg.get_logger(__name__)
 
 def main():
     argparse = ArgumentParser(description='Delete/Archive submission')
-    argparse.add_argument('--eload', required=True, type=int, help='The ELOAD number of the submission.')
+    target = argparse.add_mutually_exclusive_group(required=True)
+    target.add_argument('--submission_id', required=False, type=str,
+                        help='Submission ID, converted to ELOAD for downstream processing')
+    target.add_argument('--eload', required=False, type=int, help='The ELOAD number for this submission')
     argparse.add_argument('--ftp_box', required=False, type=int, choices=range(1, 21), default=None,
                           help='box number where the data has been uploaded')
     argparse.add_argument('--submitter', required=False, type=str, help='the name of the directory for the submitter')
@@ -45,8 +50,17 @@ def main():
     # Load the config_file from default location
     load_config()
 
+    if args.submission_id:
+        submission = fetch_submission(args.submission_id)
+        if not submission:
+            logger.error(f'Submission {args.submission_id} not found')
+            sys.exit(1)
+        eload_id = submission.get('eloadId')
+    else:
+        eload_id = args.eload
+
     # Do NOT use context manager to ensure the Eload object does not rewrite the config after deletion!
-    submission_deletion = EloadDeletion(args.eload)
+    submission_deletion = EloadDeletion(eload_id)
     submission_deletion.delete_submission(args.ftp_box, args.submitter, args.force_delete)
 
 

--- a/bin/ingest_submission.py
+++ b/bin/ingest_submission.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import logging
+import sys
 from argparse import ArgumentParser
 from copy import copy
 
@@ -31,7 +32,10 @@ def main():
     default_tasks = copy(EloadIngestion.all_tasks)
     default_tasks.remove('archive_only')
     argparse = ArgumentParser(description='Accession and ingest submission data into EVA')
-    argparse.add_argument('--eload', required=True, type=int, help='The ELOAD number for this submission.')
+    target = argparse.add_mutually_exclusive_group(required=True)
+    target.add_argument('--submission_id', required=False, type=str,
+                        help='Submission ID, converted to ELOAD for downstream processing')
+    target.add_argument('--eload', required=False, type=int, help='The ELOAD number for this submission')
     argparse.add_argument('--tasks', required=False, type=str, nargs='+',
                           default=default_tasks, choices=EloadIngestion.all_tasks,
                           help='Task or set of tasks to perform during ingestion.')
@@ -56,7 +60,16 @@ def main():
     # Load the config_file from default location
     load_config()
 
-    with EloadIngestion(args.eload, nextflow_config=args.nextflow_config) as ingestion:
+    if args.submission_id:
+        submission = sub_cli_utils.fetch_submission(args.submission_id)
+        if not submission:
+            logger.error(f'Submission {args.submission_id} not found')
+            sys.exit(1)
+        eload_id = submission.get('eloadId')
+    else:
+        eload_id = args.eload
+
+    with EloadIngestion(eload_id, nextflow_config=args.nextflow_config) as ingestion:
         ingestion.upgrade_to_new_version_if_needed()
         try:
             ingestion.run_ingestion_and_qc_result(

--- a/bin/qc_submission.py
+++ b/bin/qc_submission.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+import sys
 # Copyright 2020 EMBL - European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,7 @@ from argparse import ArgumentParser
 
 from ebi_eva_common_pyutils.logger import logging_config as log_cfg
 
+from eva_sub_cli_processing.sub_cli_utils import fetch_submission
 from eva_submission.submission_qc_checks import EloadQC
 from eva_submission.submission_config import load_config
 
@@ -26,7 +27,10 @@ logger = log_cfg.get_logger(__name__)
 
 def main():
     argparse = ArgumentParser(description='Run QC checks on the submitted eload')
-    argparse.add_argument('--eload', required=True, type=int, help='The ELOAD number of the submission.')
+    target = argparse.add_mutually_exclusive_group(required=True)
+    target.add_argument('--submission_id', required=False, type=str,
+                        help='Submission ID, converted to ELOAD for downstream processing')
+    target.add_argument('--eload', required=False, type=int, help='The ELOAD number for this submission')
 
     args = argparse.parse_args()
 
@@ -35,7 +39,16 @@ def main():
     # Load the config_file from default location
     load_config()
 
-    with EloadQC(args.eload) as eload_qc:
+    if args.submission_id:
+        submission = fetch_submission(args.submission_id)
+        if not submission:
+            logger.error(f'Submission {args.submission_id} not found')
+            sys.exit(1)
+        eload_id = submission.get('eloadId')
+    else:
+        eload_id = args.eload
+
+    with EloadQC(eload_id) as eload_qc:
         eload_qc.run_qc_checks_for_submission()
 
 

--- a/bin/validate_submission.py
+++ b/bin/validate_submission.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import logging
+import sys
 from argparse import ArgumentParser
 
 from ebi_eva_common_pyutils.logger import logging_config as log_cfg
@@ -28,7 +29,10 @@ logger = log_cfg.get_logger(__name__)
 
 def main():
     argparse = ArgumentParser(description='Validate an ELOAD by checking the data and metadata format and semantics.')
-    argparse.add_argument('--eload', required=True, type=int, help='The ELOAD number for this submission')
+    target = argparse.add_mutually_exclusive_group(required=True)
+    target.add_argument('--submission_id', required=False, type=str,
+                        help='Submission ID, converted to ELOAD for downstream processing')
+    target.add_argument('--eload', required=False, type=int, help='The ELOAD number for this submission')
     argparse.add_argument('--validation_tasks', required=False, type=str, nargs='+',
                           default=EloadValidation.all_validation_tasks, choices=EloadValidation.all_validation_tasks,
                           help='task or set of tasks to perform during validation')
@@ -59,7 +63,16 @@ def main():
     # Load the config_file from default location
     load_config()
 
-    with EloadValidation(args.eload, nextflow_config=args.nextflow_config) as eload:
+    if args.submission_id:
+        submission = sub_cli_utils.fetch_submission(args.submission_id)
+        if not submission:
+            logger.error(f'Submission {args.submission_id} not found')
+            sys.exit(1)
+        eload_id = submission.get('eloadId')
+    else:
+        eload_id = args.eload
+
+    with EloadValidation(eload_id, nextflow_config=args.nextflow_config) as eload:
         eload.upgrade_to_new_version_if_needed()
         if not args.report:
             try:


### PR DESCRIPTION
I did not change all the executables, since some work off a project accession and others I'm not sure would be used in future automation (e.g. prepare_backlog).

Integration tests [here](https://github.com/EBIvariation/eva-integration-tests/actions/runs/30364388976).